### PR TITLE
Pass the correct CFLAGs for Rpi3 and Rpi4 when both models run a syst…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,8 @@ endif
 ifeq ($(NON_MATCHING),1)
   VERSION_CFLAGS := $(VERSION_CFLAGS) -DNON_MATCHING -DAVOID_UB
     ifeq ($(TARGET_RPI),1) # Define RPi to change SDL2 title & GLES2 hints
-      VERSION_CFLAGS += -DTARGET_RPI
+      # Other platforms will use GLES2 eventually, not only RPis.
+      VERSION_CFLAGS += -DUSE_GLES
     endif
   VERSION_ASFLAGS := --defsym AVOID_UB=1
   COMPARE := 0

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ ifeq ($(TARGET_RPI),1)
                 OPT_FLAGS := -march=armv6zk+fp -mfpu=vfp -Ofast
         endif
 
-# Raspberry Pi 2 and 3
+# Raspberry Pi 2 and 3 in ARM 32bit mode
         ifneq (,$(findstring armv7l,$(machine)))
                 model = $(shell sh -c 'cat /sys/firmware/devicetree/base/model 2>/dev/null || echo unknown')
 
@@ -276,9 +276,15 @@ ifeq ($(TARGET_RPI),1)
                 endif
         endif
 
-# RPi4 / ARM A64 NEEDS TESTING 32BIT.
+# RPi3 or RPi4, in ARM64 (aarch64) mode. NEEDS TESTING 32BIT.
+# DO NOT pass -mfpu stuff here, thats for 32bit ARM only and will fail for 64bit ARM.
         ifneq (,$(findstring aarch64,$(machine)))
-                 OPT_FLAGS := -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -O3
+                model = $(shell sh -c 'cat /sys/firmware/devicetree/base/model 2>/dev/null || echo unknown')
+                ifneq (,$(findstring 3,$(model)))
+                         OPT_FLAGS := -march=armv8-a+crc -mtune=cortex-a53 -O3
+                else ifneq (,$(findstring 4,$(model)))
+                         OPT_FLAGS := -march=armv8-a+crc+simd -mtune=cortex-a72 -O3
+                endif
         endif
 endif
 

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -100,7 +100,7 @@ static void gfx_sdl_init(void) {
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-    #ifdef TARGET_RPI
+    #ifdef USE_GLES
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);  // These attributes allow for hardware acceleration on RPis.
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
@@ -109,18 +109,18 @@ static void gfx_sdl_init(void) {
     //SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
     //SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
     
-    #ifndef TARGET_RPI
-    wnd = SDL_CreateWindow("Super Mario 64 PC-Port", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+    #ifndef USE_GLES
+    wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
             DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
     #else
-    wnd = SDL_CreateWindow("Super Mario 64 RPi (GLES2)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+    wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL_ES2)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
             DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
     #endif
   
     gfx_sdl_set_fullscreen(configFullscreen);
     
     SDL_GL_CreateContext(wnd);
-    SDL_GL_SetSwapInterval(2); // TODO 0, 1 or 2 or remove this line
+    SDL_GL_SetSwapInterval(1); // We have a double buffered GL context, it makes no sense to want tearing.
     
     for (size_t i = 0; i < sizeof(windows_scancode_table) / sizeof(SDL_Scancode); i++) {
         inverted_scancode_table[windows_scancode_table[i]] = i;


### PR DESCRIPTION
…em with aarch64 kernel and libs.

Previously, ARM32 and aarch64 flags were mixed and wrong (ie: aarch64 does not build with -mfpu, Pi4 was receiving Pi3 CFLAGs, etc). 