### PR TITLE
Change menu and level sleep frames to fix TAS syncing

### DIFF
--- a/levels/menu/script.c
+++ b/levels/menu/script.c
@@ -50,7 +50,7 @@ const LevelScript level_main_menu_entry_1[] = {
     GET_OR_SET(/*op*/ OP_SET, /*var*/ VAR_CURR_SAVE_FILE_NUM),
     STOP_MUSIC(/*fadeOutTime*/ 0x00BE),
     TRANSITION(/*transType*/ WARP_TRANSITION_FADE_INTO_COLOR, /*time*/ 16, /*color*/ 0xFF, 0xFF, 0xFF),
-    SLEEP(/*frames*/ 24),
+    SLEEP(/*frames*/ 16),
     CLEAR_LEVEL(),
     SLEEP_BEFORE_EXIT(/*frames*/ 1),
     SET_REG(/*value*/ LEVEL_CASTLE_GROUNDS),
@@ -89,7 +89,7 @@ const LevelScript level_main_menu_entry_2[] = {
     /*35*/ GET_OR_SET(/*op*/ OP_SET, /*var*/ VAR_CURR_ACT_NUM),
     /*36*/ STOP_MUSIC(/*fadeOutTime*/ 0x00BE),
     /*37*/ TRANSITION(/*transType*/ WARP_TRANSITION_FADE_INTO_COLOR, /*time*/ 16, /*color*/ 0xFF, 0xFF, 0xFF),
-    /*39*/ SLEEP(/*frames*/ 24),
+    /*39*/ SLEEP(/*frames*/ 16),
     /*40*/ CLEAR_LEVEL(),
     /*41*/ SLEEP_BEFORE_EXIT(/*frames*/ 1),
     // L1:


### PR DESCRIPTION
Changed amount of sleep frames when transitioning from main menu and exiting a stage to fix TAS sync issues