### PR TITLE
Use the system video mode in GLES platforms instead of setting a new …

### DIFF
--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -95,6 +95,8 @@ static void gfx_sdl_set_fullscreen(bool fullscreen)
 }
 
 static void gfx_sdl_init(void) {
+    Uint32 window_flags = 0;
+
     SDL_Init(SDL_INIT_VIDEO);
 	
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
@@ -108,21 +110,27 @@ static void gfx_sdl_init(void) {
     
     //SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
     //SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
-    
+
+    window_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
+
+    if (configFullscreen) {
+        window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+    }
+
+ 
     #ifndef USE_GLES
     wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-            DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+            DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, window_flags);
     #else
     /* GLES platforms generally run without a window server like Xorg. Just use the system video mode,
        instead of trying to set a new video mode, which does not make any sense in modern displays. */
     SDL_DisplayMode sdl_displaymode;
     SDL_GetCurrentDisplayMode(0, &sdl_displaymode); 
+
     wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL_ES2)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-            sdl_displaymode.w, sdl_displaymode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+            sdl_displaymode.w, sdl_displaymode.h, window_flags);
     #endif
   
-    gfx_sdl_set_fullscreen(configFullscreen);
-    
     SDL_GL_CreateContext(wnd);
     SDL_GL_SetSwapInterval(1); // We have a double buffered GL context, it makes no sense to want tearing.
     

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -113,8 +113,10 @@ static void gfx_sdl_init(void) {
     wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
             DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
     #else
+    /* GLES platforms generally run without a window server like Xorg. Just use the system video mode,
+       instead of trying to set a new video mode, which does not make any sense in modern displays. */
     wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL_ES2)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-            DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+            0, 0, SDL_WINDOW_OPENGL | SDL_WINDOW_FULLSCREEN_DESKTOP);
     #endif
   
     gfx_sdl_set_fullscreen(configFullscreen);

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -115,8 +115,10 @@ static void gfx_sdl_init(void) {
     #else
     /* GLES platforms generally run without a window server like Xorg. Just use the system video mode,
        instead of trying to set a new video mode, which does not make any sense in modern displays. */
+    SDL_DisplayMode sdl_displaymode;
+    SDL_GetCurrentDisplayMode(0, &sdl_displaymode); 
     wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL_ES2)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-            0, 0, SDL_WINDOW_OPENGL | SDL_WINDOW_FULLSCREEN_DESKTOP);
+            sdl_displaymode.w, sdl_displaymode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_FULLSCREEN_DESKTOP);
     #endif
   
     gfx_sdl_set_fullscreen(configFullscreen);

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -117,19 +117,23 @@ static void gfx_sdl_init(void) {
         window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
 
- 
-    #ifndef USE_GLES
-    wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-            DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, window_flags);
-    #else
-    /* GLES platforms generally run without a window server like Xorg. Just use the system video mode,
-       instead of trying to set a new video mode, which does not make any sense in modern displays. */
     SDL_DisplayMode sdl_displaymode;
     SDL_GetCurrentDisplayMode(0, &sdl_displaymode); 
 
-    wnd = SDL_CreateWindow("Super Mario 64 PC port (OpenGL_ES2)", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-            sdl_displaymode.w, sdl_displaymode.h, window_flags);
+    const char* window_title = 
+    #ifndef USE_GLES
+    "Super Mario 64 PC port (OpenGL)";
+    #else
+    "Super Mario 64 PC port (OpenGL_ES2)";
     #endif
+
+    if (configFullscreen) {
+        wnd = SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                sdl_displaymode.w, sdl_displaymode.h, window_flags);
+    } else {
+        wnd = SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, window_flags);
+    }
   
     SDL_GL_CreateContext(wnd);
     SDL_GL_SetSwapInterval(1); // We have a double buffered GL context, it makes no sense to want tearing.


### PR DESCRIPTION
GLES systems dont have a windowing system in general, so there is no need to specify window size. Also, it makes no sense to change the physical video mode in modern displays.