### PR TITLE
WIP Addition of in-game menu quit (savescreen + pausescreen)

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -3,21 +3,6 @@
 
 #include "text_menu_strings.h"
 
-#define NC_CAMX 				_("Camera X Sensitivity")
-#define NC_CAMY 				_("Camera Y Sensitivity")
-#define NC_INVERTX				_("Invert X Axis")
-#define NC_INVERTY				_("Invert Y Axis")
-#define NC_CAMC 				_("Camera Centre Aggression")
-#define NC_CAMP 				_("Camera Pan Level")
-#define NC_ENABLED 				_("Enabled")
-#define NC_DISABLED 			_("Disabled")
-#define NC_BUTTON 				_("[R]: Options")
-#define NC_BUTTON2 				_("[R]: Return")
-#define NC_OPTION 				_("OPTIONS")
-#define NC_HIGHLIGHT 			_("O")
-#define NC_ANALOGUE				_("Analogue Camera")
-#define NC_MOUSE				_("Mouse Look")
-
 /**
  * Global Symbols
  */
@@ -122,6 +107,7 @@
 // Save Options
 #define TEXT_SAVE_AND_CONTINUE _("セーブしてつづける？")
 #define TEXT_SAVE_AND_QUIT _("セーブしておわる？")
+#define TEXT_EXIT_GAME
 #define TEXT_CONTINUE_WITHOUT_SAVING _("セーブしないでつづける？")
 
 /**
@@ -204,7 +190,9 @@
 #define TEXT_MYSCORE _("MYSCORE")
 #define TEXT_CONTINUE _("CONTINUE")
 #define TEXT_EXIT_COURSE _("EXIT COURSE")
+#define TEXT_EXIT_GAME _("EXIT GAME")
 #ifndef VERSION_EU // "R" text is different in EU
+#define TEXT_EXIT_GAME _("EXIT GAME")
 #define TEXT_CAMERA_ANGLE_R _("SET CAMERA ANGLE WITH R")
 #endif
 

--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -124,6 +124,7 @@
 // Save Options
 #define TEXT_SAVE_AND_CONTINUE _("セーブしてつづける？")
 #define TEXT_SAVE_AND_QUIT _("セーブしておわる？")
+#define TEXT_EXIT_GAME _("Exit Game")
 #define TEXT_CONTINUE_WITHOUT_SAVING _("セーブしないでつづける？")
 
 /**

--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -3,6 +3,23 @@
 
 #include "text_menu_strings.h"
 
+
+#define NC_CAMX					_("Camera X Sensitivity")
+#define NC_CAMY					_("Camera Y Sensitivity")
+#define NC_INVERTX				_("Invert X Axis")
+#define NC_INVERTY				_("Invert Y Axis")
+#define NC_CAMC					_("Camera Centre Aggression")
+#define NC_CAMP					_("Camera Pan Level")
+#define NC_ENABLED				_("Enabled")
+#define NC_DISABLED				_("Disabled")
+#define NC_BUTTON				_("[R]: Options")
+#define NC_BUTTON2				_("[R]: Return")
+#define NC_OPTION				_("OPTIONS")
+#define NC_HIGHLIGHT				_("O")
+#define NC_ANALOGUE				_("Analogue Camera")
+#define NC_MOUSE				_("Mouse Look")
+
+
 /**
  * Global Symbols
  */
@@ -107,7 +124,6 @@
 // Save Options
 #define TEXT_SAVE_AND_CONTINUE _("セーブしてつづける？")
 #define TEXT_SAVE_AND_QUIT _("セーブしておわる？")
-#define TEXT_EXIT_GAME
 #define TEXT_CONTINUE_WITHOUT_SAVING _("セーブしないでつづける？")
 
 /**

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -19,6 +19,9 @@
 #include "print.h"
 #include "engine/math_util.h"
 #include "course_table.h"
+#ifdef BETTERCAMERA
+#include "bettercamera.h"
+#endif
 
 extern Gfx *gDisplayListHead;
 extern s16 gCurrCourseNum;
@@ -2420,7 +2423,7 @@ void render_pause_course_options(s16 x, s16 y, s8 *index, s16 yIndex) {
     }
 
     if (index[0] == 4) {
-        render_pause_camera_options(x - 42, y - 42, &gDialogCameraAngleIndex, 110);
+        render_pause_camera_options(x - 42, y - 59, &gDialogCameraAngleIndex, 110);
     }
 }
 
@@ -2618,6 +2621,11 @@ s16 render_pause_courses_and_castle(void) {
     gInGameLanguage = eu_get_language();
 #endif
 
+#ifdef BETTERCAMERA
+    if (newcam_option_open == 0)
+    {
+#endif
+
     switch (gDialogBoxState) {
         case DIALOG_STATE_OPENING:
             gDialogLineNum = 1;
@@ -2693,6 +2701,18 @@ s16 render_pause_courses_and_castle(void) {
     if (gDialogTextAlpha < 250) {
         gDialogTextAlpha += 25;
     }
+
+#ifdef BETTERCAMERA
+    }
+    else
+    {
+        shade_screen();
+        newcam_display_options();
+    }
+    newcam_check_pause_buttons();
+    newcam_render_option_text();
+#endif
+
 
     return 0;
 }

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -19,9 +19,6 @@
 #include "print.h"
 #include "engine/math_util.h"
 #include "course_table.h"
-#ifdef BETTERCAMERA
-#include "bettercamera.h"
-#endif
 
 extern Gfx *gDisplayListHead;
 extern s16 gCurrCourseNum;
@@ -696,7 +693,7 @@ void print_credits_string(s16 x, s16 y, const u8 *str) {
     gDPSetTile(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, G_TX_LOADTILE, 0,
                 G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOLOD, G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOLOD);
     gDPTileSync(gDisplayListHead++);
-    gDPSetTile(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 2, 0, G_TX_RENDERTILE, 0,
+    gDPSetTile(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 2, 0, G_TX_RENDERTILE, 0, 
                 G_TX_CLAMP, 3, G_TX_NOLOD, G_TX_CLAMP, 3, G_TX_NOLOD);
     gDPSetTileSize(gDisplayListHead++, G_TX_RENDERTILE, 0, 0, (8 - 1) << G_TEXTURE_IMAGE_FRAC, (8 - 1) << G_TEXTURE_IMAGE_FRAC);
 
@@ -2394,23 +2391,25 @@ void render_pause_course_options(s16 x, s16 y, s8 *index, s16 yIndex) {
     };
 #define textContinue     textContinue[gInGameLanguage]
 #define textExitCourse   textExitCourse[gInGameLanguage]
+#define textExitGame     textExitGame
 #define textCameraAngleR textCameraAngleR[gInGameLanguage]
 #else
     u8 textContinue[] = { TEXT_CONTINUE };
     u8 textExitCourse[] = { TEXT_EXIT_COURSE };
+    u8 textExitGame[] = { TEXT_EXIT_GAME };
     u8 textCameraAngleR[] = { TEXT_CAMERA_ANGLE_R };
 #endif
 
-    handle_menu_scrolling(MENU_SCROLL_VERTICAL, index, 1, 3);
+    handle_menu_scrolling(MENU_SCROLL_VERTICAL, index, 1, 4);
 
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
 
     print_generic_string(x + 10, y - 2, textContinue);
     print_generic_string(x + 10, y - 17, textExitCourse);
-
-    if (index[0] != 3) {
-        print_generic_string(x + 10, y - 33, textCameraAngleR);
+    print_generic_string(x + 10, y - 33, textExitGame);
+    if (index[0] != 4) {
+        print_generic_string(x + 10, y - 48, textCameraAngleR);
         gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
 
         create_dl_translation_matrix(MENU_MTX_PUSH, x - X_VAL8, (y - ((index[0] - 1) * yIndex)) - Y_VAL8, 0);
@@ -2420,7 +2419,7 @@ void render_pause_course_options(s16 x, s16 y, s8 *index, s16 yIndex) {
         gSPPopMatrix(gDisplayListHead++, G_MTX_MODELVIEW);
     }
 
-    if (index[0] == 3) {
+    if (index[0] == 4) {
         render_pause_camera_options(x - 42, y - 42, &gDialogCameraAngleIndex, 110);
     }
 }
@@ -2618,10 +2617,7 @@ s16 render_pause_courses_and_castle(void) {
 #ifdef VERSION_EU
     gInGameLanguage = eu_get_language();
 #endif
-#ifdef BETTERCAMERA
-    if (newcam_option_open == 0)
-    {
-#endif
+
     switch (gDialogBoxState) {
         case DIALOG_STATE_OPENING:
             gDialogLineNum = 1;
@@ -2662,7 +2658,7 @@ s16 render_pause_courses_and_castle(void) {
                 gDialogBoxState = DIALOG_STATE_OPENING;
                 gMenuMode = -1;
 
-                if (gDialogLineNum == 2) {
+                if (gDialogLineNum == 2 || gDialogLineNum == 3) {
                     num = gDialogLineNum;
                 } else {
                     num = 1;
@@ -2697,16 +2693,6 @@ s16 render_pause_courses_and_castle(void) {
     if (gDialogTextAlpha < 250) {
         gDialogTextAlpha += 25;
     }
-#ifdef BETTERCAMERA
-    }
-    else
-    {
-        shade_screen();
-        newcam_display_options();
-    }
-    newcam_check_pause_buttons();
-    newcam_render_option_text();
-#endif
 
     return 0;
 }
@@ -2953,7 +2939,8 @@ void render_course_complete_lvl_info_and_hud_str(void) {
 #else
 #define TXT_SAVECONT_Y 0
 #define TXT_SAVEQUIT_Y 20
-#define TXT_CONTNOSAVE_Y 40
+#define TXT_EXIT_GAME_Y 40
+#define TXT_CONTNOSAVE_Y 60
 #endif
 
 #ifdef VERSION_EU
@@ -2987,16 +2974,18 @@ void render_save_confirmation(s16 x, s16 y, s8 *index, s16 sp6e)
 #else
     u8 textSaveAndContinue[] = { TEXT_SAVE_AND_CONTINUE };
     u8 textSaveAndQuit[] = { TEXT_SAVE_AND_QUIT };
+    u8 textExitGame[] = { TEXT_EXIT_GAME };
     u8 textContinueWithoutSave[] = { TEXT_CONTINUE_WITHOUT_SAVING };
 #endif
 
-    handle_menu_scrolling(MENU_SCROLL_VERTICAL, index, 1, 3);
+    handle_menu_scrolling(MENU_SCROLL_VERTICAL, index, 1, 4);
 
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
 
     print_generic_string(TXT_SAVEOPTIONS_X, y + TXT_SAVECONT_Y, textSaveAndContinue);
     print_generic_string(TXT_SAVEOPTIONS_X, y - TXT_SAVEQUIT_Y, textSaveAndQuit);
+    print_generic_string(TXT_SAVEOPTIONS_X, y - TXT_EXIT_GAME_Y, textExitGame);
     print_generic_string(TXT_SAVEOPTIONS_X, y - TXT_CONTNOSAVE_Y, textContinueWithoutSave);
 
     gSPDisplayList(gDisplayListHead++, dl_ia_text_end);

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -27,6 +27,7 @@
 #include "level_table.h"
 #include "course_table.h"
 #include "thread6.h"
+#include <stdlib.h>
 
 #define PLAY_MODE_NORMAL 0
 #define PLAY_MODE_PAUSED 2
@@ -1017,19 +1018,29 @@ s32 play_mode_paused(void) {
         raise_background_noise(1);
         gCameraMovementFlags &= ~CAM_MOVE_PAUSE_SCREEN;
         set_play_mode(PLAY_MODE_NORMAL);
-    } else {
+    }
+
+	else if (gPauseScreenMode == 2) {
         // Exit level
 
         if (gDebugLevelSelect) {
             fade_into_special_warp(-9, 1);
-        } else {
+       	 }
+
+	else {
             initiate_warp(LEVEL_CASTLE, 1, 0x1F, 0);
             fade_into_special_warp(0, 0);
             gSavedCourseNum = COURSE_NONE;
         }
 
+      } //gPauseScreenMode == 2
+
+      if (gPauseScreenMode == 3) { // We should only be getting "int 3" to here
+	    exit(0);
+	}
+
         gCameraMovementFlags &= ~CAM_MOVE_PAUSE_SCREEN;
-    }
+    // there was a } here? Hmm. 
 
     return 0;
 }

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -27,9 +27,10 @@
 #include "level_table.h"
 #include "dialog_ids.h"
 #include "thread6.h"
+#include <stdlib.h>
 
 // TODO: put this elsewhere
-enum SaveOption { SAVE_OPT_SAVE_AND_CONTINUE = 1, SAVE_OPT_SAVE_AND_QUIT, SAVE_OPT_CONTINUE_DONT_SAVE };
+enum SaveOption { SAVE_OPT_SAVE_AND_CONTINUE = 1, SAVE_OPT_SAVE_AND_QUIT, SAVE_OPT_EXIT_GAME, SAVE_OPT_CONTINUE_DONT_SAVE };
 
 static struct Object *sIntroWarpPipeObj;
 static struct Object *sEndPeachObj;
@@ -254,16 +255,20 @@ void handle_save_menu(struct MarioState *m) {
     // mario_finished_animation(m) ? (not my file, not my problem)
     if (is_anim_past_end(m) && gSaveOptSelectIndex != 0) {
         // save and continue / save and quit
-        if (gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_CONTINUE || gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_QUIT) {
+        if (gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_CONTINUE || gSaveOptSelectIndex == SAVE_OPT_EXIT_GAME || gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_QUIT ) {
             save_file_do_save(gCurrSaveFileNum - 1);
 
             if (gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_QUIT) {
                 fade_into_special_warp(-2, 0); // reset game
             }
+            if (gSaveOptSelectIndex == SAVE_OPT_EXIT_GAME) {
+                exit(0);  // exit after setting game
+            }
+
         }
 
         // not quitting
-        if (gSaveOptSelectIndex != SAVE_OPT_SAVE_AND_QUIT) {
+        if (gSaveOptSelectIndex != SAVE_OPT_EXIT_GAME) {
             disable_time_stop();
             m->faceAngle[1] += 0x8000;
             // figure out what dialog to show, if we should


### PR DESCRIPTION
**Warning: May not work on non-US builds atm. All files must be merged at once as well**

Adds a full (If forceful) quit/exit to the standard pause menu.

Exit game in SAVE dialogue *saves* before exiting the game. 

https://cdn.discordapp.com/attachments/706395232492847104/709059050364600330/mario64-exitgame.jpg 

https://cdn.discordapp.com/attachments/706395232492847104/709059052851953715/mario64-exitgame2.jpg