### PR TITLE
Hide mouse cursor when in fullscreen mode.

### DIFF
--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -130,9 +130,11 @@ static void gfx_sdl_init(void) {
     if (configFullscreen) {
         wnd = SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
                 sdl_displaymode.w, sdl_displaymode.h, window_flags);
+        SDL_ShowCursor(SDL_DISABLE);
     } else {
         wnd = SDL_CreateWindow(window_title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
                 DESIRED_SCREEN_WIDTH, DESIRED_SCREEN_HEIGHT, window_flags);
+        SDL_ShowCursor(SDL_ENABLE);
     }
   
     SDL_GL_CreateContext(wnd);


### PR DESCRIPTION
It was broken by my recent changes. Now it works again as expected.