### PR TITLE
only enable mouse controls with mouse look

### DIFF
--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -52,13 +52,13 @@ unsigned int configJoyStart      = 6;
 unsigned int configJoyL          = 7;
 unsigned int configJoyR          = 10;
 unsigned int configJoyZ          = 9;
+#ifdef BETTERCAMERA
 // Mouse button mappings (0 for none, 1 for left, 2 for middle, 3 for right)
 unsigned int configMouseA        = 3;
 unsigned int configMouseB        = 1;
 unsigned int configMouseL        = 4;
 unsigned int configMouseR        = 5;
 unsigned int configMouseZ        = 2;
-#ifdef BETTERCAMERA
 // BetterCamera settings
 unsigned int configCameraXSens   = 50;
 unsigned int configCameraYSens   = 50;
@@ -92,12 +92,12 @@ static const struct ConfigOption options[] = {
     {.name = "joy_l",                .type = CONFIG_TYPE_UINT, .uintValue = &configJoyL},
     {.name = "joy_r",                .type = CONFIG_TYPE_UINT, .uintValue = &configJoyR},
     {.name = "joy_z",                .type = CONFIG_TYPE_UINT, .uintValue = &configJoyZ},
+#ifdef BETTERCAMERA
     {.name = "mouse_a",              .type = CONFIG_TYPE_UINT, .uintValue = &configMouseA},
     {.name = "mouse_b",              .type = CONFIG_TYPE_UINT, .uintValue = &configMouseB},
     {.name = "mouse_l",              .type = CONFIG_TYPE_UINT, .uintValue = &configMouseL},
     {.name = "mouse_r",              .type = CONFIG_TYPE_UINT, .uintValue = &configMouseR},
     {.name = "mouse_z",              .type = CONFIG_TYPE_UINT, .uintValue = &configMouseZ},
-    #ifdef BETTERCAMERA
     {.name = "bettercam_enable",     .type = CONFIG_TYPE_BOOL, .boolValue = &configEnableCamera},
     {.name = "bettercam_mouse_look", .type = CONFIG_TYPE_BOOL, .boolValue = &configCameraMouse},
     {.name = "bettercam_invertx",    .type = CONFIG_TYPE_BOOL, .boolValue = &configCameraInvertX},
@@ -106,7 +106,7 @@ static const struct ConfigOption options[] = {
     {.name = "bettercam_ysens",      .type = CONFIG_TYPE_UINT, .uintValue = &configCameraYSens},
     {.name = "bettercam_aggression", .type = CONFIG_TYPE_UINT, .uintValue = &configCameraAggr},
     {.name = "bettercam_pan_level",  .type = CONFIG_TYPE_UINT, .uintValue = &configCameraPan},
-    #endif
+#endif
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -26,13 +26,13 @@ extern unsigned int configJoyStart;
 extern unsigned int configJoyL;
 extern unsigned int configJoyR;
 extern unsigned int configJoyZ;
+#ifdef BETTERCAMERA
 extern unsigned int configMouseA;
 extern unsigned int configMouseB;
 extern unsigned int configMouseStart;
 extern unsigned int configMouseL;
 extern unsigned int configMouseR;
 extern unsigned int configMouseZ;
-#ifdef BETTERCAMERA
 extern unsigned int configCameraXSens;
 extern unsigned int configCameraYSens;
 extern unsigned int configCameraAggr;

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -55,11 +55,14 @@ static void controller_sdl_read(OSContPad *pad) {
     
     const u32 mbuttons = SDL_GetRelativeMouseState(&mouse_x, &mouse_y);
     
-    if (configMouseA && (mbuttons & SDL_BUTTON(configMouseA))) pad->button |= A_BUTTON;
-    if (configMouseB && (mbuttons & SDL_BUTTON(configMouseB))) pad->button |= B_BUTTON;
-    if (configMouseL && (mbuttons & SDL_BUTTON(configMouseL))) pad->button |= L_TRIG;
-    if (configMouseR && (mbuttons & SDL_BUTTON(configMouseR))) pad->button |= R_TRIG;
-    if (configMouseZ && (mbuttons & SDL_BUTTON(configMouseZ))) pad->button |= Z_TRIG;
+    if (configCameraMouse)
+    {   
+        if (configMouseA && (mbuttons & SDL_BUTTON(configMouseA))) pad->button |= A_BUTTON;
+        if (configMouseB && (mbuttons & SDL_BUTTON(configMouseB))) pad->button |= B_BUTTON;
+        if (configMouseL && (mbuttons & SDL_BUTTON(configMouseL))) pad->button |= L_TRIG;
+        if (configMouseR && (mbuttons & SDL_BUTTON(configMouseR))) pad->button |= R_TRIG;
+        if (configMouseZ && (mbuttons & SDL_BUTTON(configMouseZ))) pad->button |= Z_TRIG;
+    }
 #endif
 
     SDL_GameControllerUpdate();


### PR DESCRIPTION
I feel like its redundant to have mouse controls without having mouse look enabled
I've also moved all mouse input related configs into the BETTERCAMERA block since they aren't actually used with the stock camera

https://github.com/sm64pc/sm64pc/blob/d0b85785fe8956069fbda113816dc196b2606701/src/pc/controller/controller_sdl.c#L50-L63