### PR TITLE
Add command line parsing and --skip-intro option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# sm64pc  - skipintro branch
-
-This is a testing branch featuring a new CLI interface and support to skip the introductory Peach & Lakitu cutscenes, useful for development tests.
-
+# sm64pc
 OpenGL adaptation of [n64decomp/sm64](https://github.com/n64decomp/sm64). 
 
 Feel free to report bugs and contribute, but remember, there must be **no upload of any copyrighted asset**. 
@@ -13,6 +10,7 @@ Run `./extract-assets.py --clean && make clean` or `make distclean` to remove RO
  * Variable aspect ratio and resolution. The game can now correctly render at basically any window size.
  * Native xinput controller support. On Linux, DualShock 4 has been confirmed to work plug-and-play.
  * Analog camera control and mouse look. (Activate with `make BETTERCAMERA=1`.)
+ * Option to skip the Peach/Lakitu new file intro.
 
 ## Building
 For building instructions, please refer to the [wiki](https://github.com/sm64pc/sm64pc/wiki).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# sm64pc
+# sm64pc  - skipintro branch
+
+This is a testing branch featuring a new CLI interface and support to skip the introductory Peach & Lakitu cutscenes, useful for development tests.
+
 OpenGL adaptation of [n64decomp/sm64](https://github.com/n64decomp/sm64). 
 
 Feel free to report bugs and contribute, but remember, there must be **no upload of any copyrighted asset**. 

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -28,6 +28,8 @@
 #include "course_table.h"
 #include "thread6.h"
 
+#include "pc/cliopts.h"
+
 #define PLAY_MODE_NORMAL 0
 #define PLAY_MODE_PAUSED 2
 #define PLAY_MODE_CHANGE_AREA 3
@@ -1197,7 +1199,7 @@ s32 init_level(void) {
                 if (gMarioState->action != ACT_UNINITIALIZED) {
                     if (save_file_exists(gCurrSaveFileNum - 1)) {
                         set_mario_action(gMarioState, ACT_IDLE, 0);
-                    } else {
+                    } else if (gCLIOpts.SkipIntro == 0) {
                         set_mario_action(gMarioState, ACT_INTRO_CUTSCENE, 0);
                         val4 = 1;
                     }

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -174,7 +174,8 @@ s8 D_8032C9E0 = 0;
 u8 unused3[4];
 u8 unused4[2];
 
-
+// For configfile intro skipping
+extern unsigned int configSkipIntro;
 
 
 void basic_update(s16 *arg);
@@ -1199,7 +1200,7 @@ s32 init_level(void) {
                 if (gMarioState->action != ACT_UNINITIALIZED) {
                     if (save_file_exists(gCurrSaveFileNum - 1)) {
                         set_mario_action(gMarioState, ACT_IDLE, 0);
-                    } else if (gCLIOpts.SkipIntro == 0) {
+                    } else if (gCLIOpts.SkipIntro == 0 && configSkipIntro == 0) {
                         set_mario_action(gMarioState, ACT_INTRO_CUTSCENE, 0);
                         val4 = 1;
                     }

--- a/src/pc/cliopts.c
+++ b/src/pc/cliopts.c
@@ -1,4 +1,5 @@
 #include "cliopts.h"
+#include <strings.h>
 
 struct PCCLIOptions gCLIOpts;
 

--- a/src/pc/cliopts.c
+++ b/src/pc/cliopts.c
@@ -1,0 +1,20 @@
+#include "cliopts.h"
+
+struct PCCLIOptions gCLIOpts;
+
+void parse_cli_opts(int argc, char* argv[])
+{
+	// Initialize options with false values. 
+	gCLIOpts.SkipIntro = 0;
+
+	// Scan arguments for options
+	if (argc > 1)
+	{
+		int i;
+		for (i = 1; i < argc; i++)
+		{
+			if (strcmp(argv[i], "--skip-intro") == 0) // Skip Peach Intro
+				gCLIOpts.SkipIntro = 1;
+		}
+	}
+}

--- a/src/pc/cliopts.h
+++ b/src/pc/cliopts.h
@@ -1,0 +1,10 @@
+#include "sm64.h"
+
+struct PCCLIOptions 
+{
+	u8 SkipIntro;
+};
+
+extern struct PCCLIOptions gCLIOpts;
+
+void parse_cli_opts(int argc, char* argv[]);

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -69,6 +69,7 @@ bool         configCameraInvertY = false;
 bool         configEnableCamera  = false;
 bool         configCameraMouse   = false;
 #endif
+unsigned int configSkipIntro     = 0;
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configFullscreen},
@@ -107,6 +108,7 @@ static const struct ConfigOption options[] = {
     {.name = "bettercam_aggression", .type = CONFIG_TYPE_UINT, .uintValue = &configCameraAggr},
     {.name = "bettercam_pan_level",  .type = CONFIG_TYPE_UINT, .uintValue = &configCameraPan},
     #endif
+    {.name = "skip_intro",           .type = CONFIG_TYPE_UINT, .uintValue = &configSkipIntro},
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -18,6 +18,7 @@
 #include "audio/audio_sdl.h"
 #include "audio/audio_null.h"
 
+#include "cliopts.h"
 #include "configfile.h"
 
 OSMesg D_80339BEC;
@@ -155,6 +156,7 @@ void main_func(void) {
 }
 
 int main(int argc, char *argv[]) {
+    parse_cli_opts(argc, argv);
     main_func();
     return 0;
 }


### PR DESCRIPTION
Adds command line parsing to pc_main which saves options on a global structure, as well as a --skip-intro command line option for skipping the Peach and Castle fly-by intro when starting a new game. 