### PR TITLE
Correct texture format for burn smoke

### DIFF
--- a/actors/burn_smoke/model.inc.c
+++ b/actors/burn_smoke/model.inc.c
@@ -44,7 +44,7 @@ const Gfx burn_smoke_seg4_dl_04022048[] = {
 // 0x04022070 - 0x040220C8
 const Gfx burn_smoke_seg4_dl_04022070[] = {
     gsSPDisplayList(burn_smoke_seg4_dl_04022000),
-    gsDPLoadTextureBlock(burn_smoke_seg4_texture_04021800, G_IM_FMT_RGBA, G_IM_SIZ_16b, 32, 32, 0, G_TX_CLAMP, G_TX_CLAMP, 5, 5, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPLoadTextureBlock(burn_smoke_seg4_texture_04021800, G_IM_FMT_IA, G_IM_SIZ_16b, 32, 32, 0, G_TX_CLAMP, G_TX_CLAMP, 5, 5, G_TX_NOLOD, G_TX_NOLOD),
     gsSPDisplayList(burn_smoke_seg4_dl_04022028),
     gsSPDisplayList(burn_smoke_seg4_dl_04022048),
     gsSPEndDisplayList(),


### PR DESCRIPTION
All credits to zoinknoise, I found this at Romhacking: http://www.romhacking.net/hacks/5008/

"Thanks to the recent decompilation efforts, it’s now known that this texture is displayed in the wrong format by the game, resulting in 

black garbage pixels. Since video game smoke of this era was often depicted with black garbage pixels, the mistake went unnoticed for over two decades. This patch corrects the error by displaying the texture correctly as proper transparent smoke. It does not add any new art; the texture has been inside the ROM all along.

At build time, this will compile the texture into IA16 format (correct) instead of RGBA16 (incorrect)."