### PR TITLE
Fix Whomp and PiranhaPlant not appearing from a distance in WF

### DIFF
--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -329,6 +329,7 @@ void (*TablePiranhaPlantActions[])(void) = {
 void bhv_piranha_plant_loop(void) {
     cur_obj_call_action_function(TablePiranhaPlantActions);
 
+    #ifndef NODRAWINGDISTANCE
     // In WF, hide all Piranha Plants once high enough up.
     if (gCurrLevelNum == LEVEL_WF) {
         if (gMarioObject->oPosY > 3400.0f)
@@ -336,5 +337,6 @@ void bhv_piranha_plant_loop(void) {
         else
             cur_obj_unhide();
     }
+    #endif
     o->oInteractStatus = 0;
 }

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -328,7 +328,6 @@ void (*TablePiranhaPlantActions[])(void) = {
  */
 void bhv_piranha_plant_loop(void) {
     cur_obj_call_action_function(TablePiranhaPlantActions);
-
     #ifndef NODRAWINGDISTANCE
     // In WF, hide all Piranha Plants once high enough up.
     if (gCurrLevelNum == LEVEL_WF) {

--- a/src/game/behaviors/sl_walking_penguin.inc.c
+++ b/src/game/behaviors/sl_walking_penguin.inc.c
@@ -97,7 +97,9 @@ void bhv_sl_walking_penguin_loop(void) {
     }
     
     cur_obj_move_standard(-78);
-    if (!cur_obj_hide_if_mario_far_away_y(1000.0f))
+#ifndef NODRAWINGDISTANCE
+     if (!cur_obj_hide_if_mario_far_away_y(1000.0f))
+#endif
         play_penguin_walking_sound(PENGUIN_WALK_BIG);
     
     // Adjust the position to get a point better lined up with the visual model, for stopping the wind.

--- a/src/game/behaviors/whomp.inc.c
+++ b/src/game/behaviors/whomp.inc.c
@@ -246,10 +246,14 @@ void bhv_whomp_loop(void) {
     cur_obj_call_action_function(sWhompActions);
     cur_obj_move_standard(-20);
     if (o->oAction != 9) {
+        #ifndef NODRAWINGDISTANCE
+        // o->oBehParams2ndByte here seems to be a flag
+        // indicating whether this is a normal or king whomp
         if (o->oBehParams2ndByte != 0)
             cur_obj_hide_if_mario_far_away_y(2000.0f);
         else
             cur_obj_hide_if_mario_far_away_y(1000.0f);
+        #endif
         load_object_collision_model();
     }
 }

--- a/src/game/behaviors/whomp.inc.c
+++ b/src/game/behaviors/whomp.inc.c
@@ -246,14 +246,14 @@ void bhv_whomp_loop(void) {
     cur_obj_call_action_function(sWhompActions);
     cur_obj_move_standard(-20);
     if (o->oAction != 9) {
-        #ifndef NODRAWINGDISTANCE
+#ifndef NODRAWINGDISTANCE
         // o->oBehParams2ndByte here seems to be a flag
         // indicating whether this is a normal or king whomp
         if (o->oBehParams2ndByte != 0)
             cur_obj_hide_if_mario_far_away_y(2000.0f);
         else
             cur_obj_hide_if_mario_far_away_y(1000.0f);
-        #endif
+#endif
         load_object_collision_model();
     }
 }


### PR DESCRIPTION
In Whomps fortress, with the NODRAWINGDISTANCE variable set, both Piranha Plants and Whomps were not being rendered when Mario was far way.