### PR TITLE
Set compile-time build flag for texture fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ COMPILER ?= ido
 BETTERCAMERA ?= 0
 # Disable no drawing distance by default
 NODRAWINGDISTANCE ?= 0
+# Disable texture fixes by default (helps with them purists)
+TEXTURE_FIX ?= 0
 
 # Build for Emscripten/WebGL
 TARGET_WEB ?= 0
@@ -456,6 +458,12 @@ endif
 ifeq ($(NODRAWINGDISTANCE),1)
 CC_CHECK += -DNODRAWINGDISTANCE
 CFLAGS += -DNODRAWINGDISTANCE
+endif
+
+# Check for texture fix option
+ifeq ($(TEXTURE_FIX),1)
+CC_CHECK += -DTEXTURE_FIX
+CFLAGS += -DTEXTURE_FIX
 endif
 
 ASFLAGS := -I include -I $(BUILD_DIR) $(VERSION_ASFLAGS)

--- a/actors/burn_smoke/model.inc.c
+++ b/actors/burn_smoke/model.inc.c
@@ -11,6 +11,9 @@ static const Vtx burn_smoke_seg4_vertex_040217C0[] = {
 // //! Wrong texture format. Called as rgba16, which makes the burn smoke appear
 //     as a transparent black burn smoke. Probably meant to show up as white-ish
 //     burn smoke, but mistakened for being intended as black smoke.
+//     Due to debate in the Koopa shorts PR surrounding the fix to a similar bug,
+//     said fix is on a compile-time variable. Use TEXTURE_FIX=1 at compile time
+//     to fix this.
 // 0x04021800
 ALIGNED8 static const u8 burn_smoke_seg4_texture_04021800[] = {
 #include "actors/burn_smoke/burn_smoke.ia16.inc.c"
@@ -44,7 +47,11 @@ const Gfx burn_smoke_seg4_dl_04022048[] = {
 // 0x04022070 - 0x040220C8
 const Gfx burn_smoke_seg4_dl_04022070[] = {
     gsSPDisplayList(burn_smoke_seg4_dl_04022000),
+    #ifdef TEXTURE_FIX
     gsDPLoadTextureBlock(burn_smoke_seg4_texture_04021800, G_IM_FMT_IA, G_IM_SIZ_16b, 32, 32, 0, G_TX_CLAMP, G_TX_CLAMP, 5, 5, G_TX_NOLOD, G_TX_NOLOD),
+    #else
+    gsDPLoadTextureBlock(burn_smoke_seg4_texture_04021800, G_IM_FMT_RGBA, G_IM_SIZ_16b, 32, 32, 0, G_TX_CLAMP, G_TX_CLAMP, 5, 5, G_TX_NOLOD, G_TX_NOLOD),
+    #endif
     gsSPDisplayList(burn_smoke_seg4_dl_04022028),
     gsSPDisplayList(burn_smoke_seg4_dl_04022048),
     gsSPEndDisplayList(),

--- a/actors/koopa/model.inc.c
+++ b/actors/koopa/model.inc.c
@@ -54,6 +54,8 @@ static const Lights1 koopa_seg6_lights_06002630 = gdSPDefLights1(
 //     beneath its shell, despite the fact it was intended to be white like
 //     the rest of its body. This is evident because once the mistake is corrected
 //     it turns back to being white like the other polygons.
+//     Due to debate in the PR surrounding the fix to this, said fix is on
+//     a compile-time variable. Use TEXTURE_FIX=1 at compile time to fix this.
 // 0x06002648
 ALIGNED8 static const u8 koopa_seg6_texture_06002648[] = {
 #include "actors/koopa/koopa_shell_front.rgba16.inc.c"
@@ -2077,8 +2079,13 @@ const Gfx koopa_seg6_dl_0600C498[] = {
     gsSPVertex(koopa_seg6_vertex_0600B560, 9, 0),
     gsSP2Triangles( 0,  1,  2, 0x0,  3,  4,  5, 0x0),
     gsSP1Triangle( 6,  7,  8, 0x0),
+    #ifdef TEXTURE_FIX
+    gsSPLight(&koopa_seg6_lights_06002630.l, 1),
+    gsSPLight(&koopa_seg6_lights_06002630.a, 2),
+    #else
     gsSPLight(koopa_seg6_texture_06002648 + 0x20, 1), // this malformed light results in a
     gsSPLight(koopa_seg6_texture_06002648 + 0x18, 2), // koopa appearing to wear pink shorts.
+    #endif
     gsSPVertex(koopa_seg6_vertex_0600B5F0, 15, 0),
     gsSP2Triangles( 0,  1,  2, 0x0,  3,  4,  5, 0x0),
     gsSP2Triangles( 6,  7,  0, 0x0,  8,  5,  9, 0x0),


### PR DESCRIPTION
This should allow for quashing the debate surrounding some minor texture fix PRs. Both the Koopa shorts fix (PR #114, corresponding issue #117) as well as the burn smoke fix (PR #112, corresponding issue https://github.com/sm64pc/sm64pc/issues/125) will be toggled on/off via this compile flag. It is my hope that future texture fixes of this nature will utilize this compile-time flag.
PR #126 fixes an incorrect behavior in regards to the wrong Koopa shorts by inspiring the fix (a different fix entirely) from https://github.com/gonetz/GLideN64/commit/c8cbafff71a81bee5112aaafe6e21d6648ff8125.
Fixes #117 
Fixes #125 