### PR TITLE
Fix small bug with MXE compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,9 +514,7 @@ ifeq ($(TARGET_WEB),1)
 LDFLAGS := -lm -lGL -lSDL2 -no-pie -s TOTAL_MEMORY=20MB -g4 --source-map-base http://localhost:8080/ -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']"
 else ifeq ($(WINDOWS_BUILD),1)
   LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -Llib -lpthread -lglew32 `$(SDLCONFIG) --static-libs` -lm -lglu32 -lsetupapi -ldinput8 -luser32 -lgdi32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion -luuid -lopengl32 -static
-  ifneq ($(CROSS),i686-w64-mingw32.static-)
-    LDFLAGS += -no-pie
-  else ifneq ($(CROSS),x86_64-w64-mingw32.static-)
+  ifeq ($(CROSS),)
     LDFLAGS += -no-pie
   endif
   ifeq ($(WINDOWS_CONSOLE),1)


### PR DESCRIPTION
The `no-pie` command line option was being sent to MXE when it shouldn't have been, breaking MXE compilation. Urgent fix.