### PR TITLE
Implement save/restore of window dimensions/position

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -27,6 +27,7 @@
 #define TEXT_OPT_NEAREST   _("Nearest")
 #define TEXT_OPT_LINEAR    _("Linear")
 #define TEXT_OPT_MVOLUME   _("Master Volume")
+#define TEXT_RESET_WINDOW  _("Reset Window")
 
 #define TEXT_OPT_UNBOUND   _("NONE")
 #define TEXT_OPT_PRESSKEY  _("...")

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -216,7 +216,7 @@ static struct Option optsControls[] = {
 };
 
 static struct Option optsVideo[] = {
-    DEF_OPT_TOGGLE( optsVideoStr[0], &configFullscreen ),
+    DEF_OPT_TOGGLE( optsVideoStr[0], &configWindow.fullscreen ),
     DEF_OPT_CHOICE( optsVideoStr[1], &configFiltering, filterChoices ),
     DEF_OPT_BUTTON( optsVideoStr[4], optvide_reset_window ),
 };

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -72,6 +72,7 @@ static const u8 optsVideoStr[][32] = {
     { TEXT_OPT_TEXFILTER },
     { TEXT_OPT_NEAREST },
     { TEXT_OPT_LINEAR },
+    { TEXT_RESET_WINDOW }
 };
 
 static const u8 optsAudioStr[][32] = {
@@ -177,6 +178,10 @@ static void optmenu_act_exit(UNUSED struct Option *self, s32 arg) {
     if (!arg) game_exit(); // only exit on A press and not directions
 }
 
+static void optvide_reset_window(UNUSED struct Option *self, s32 arg) {
+    if (!arg) configWindow.reset = true;; // Restrict reset to A press and not directions
+}
+
 /* submenu option lists */
 
 #ifdef BETTERCAMERA
@@ -213,6 +218,7 @@ static struct Option optsControls[] = {
 static struct Option optsVideo[] = {
     DEF_OPT_TOGGLE( optsVideoStr[0], &configFullscreen ),
     DEF_OPT_CHOICE( optsVideoStr[1], &configFiltering, filterChoices ),
+    DEF_OPT_BUTTON( optsVideoStr[4], optvide_reset_window ),
 };
 
 static struct Option optsAudio[] = {

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -35,7 +35,6 @@ struct ConfigOption {
  */
 
 // Video/audio stuff
-bool         configFullscreen   = false;
 ConfigWindow configWindow       = {
     .x = SDL_WINDOWPOS_CENTERED,
     .y = SDL_WINDOWPOS_CENTERED,
@@ -43,6 +42,7 @@ ConfigWindow configWindow       = {
     .h = DESIRED_SCREEN_HEIGHT,
     .reset = false,
     .vsync = false,
+    .fullscreen = false,
     .exiting_fullscreen = false,
 };
 unsigned int configFiltering    = 1;          // 0=force nearest, 1=linear, (TODO) 2=three-point
@@ -79,7 +79,7 @@ bool         configCameraMouse   = false;
 unsigned int configSkipIntro     = 0;
 
 static const struct ConfigOption options[] = {
-    {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configFullscreen},
+    {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.fullscreen},
     {.name = "window_x",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.x},
     {.name = "window_y",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.y},
     {.name = "window_w",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.w},

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -5,8 +5,10 @@
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>
+#include <SDL2/SDL.h>
 
 #include "configfile.h"
+#include "gfx/gfx_screen_config.h"
 #include "controller/controller_api.h"
 
 #define ARRAY_LEN(arr) (sizeof(arr) / sizeof(arr[0]))
@@ -34,6 +36,13 @@ struct ConfigOption {
 
 // Video/audio stuff
 bool         configFullscreen   = false;
+ConfigWindow configWindow       = {
+    .x = SDL_WINDOWPOS_CENTERED,
+    .y = SDL_WINDOWPOS_CENTERED,
+    .w = DESIRED_SCREEN_WIDTH,
+    .h = DESIRED_SCREEN_HEIGHT,
+    .reset = false
+};
 unsigned int configFiltering    = 1;          // 0=force nearest, 1=linear, (TODO) 2=three-point
 unsigned int configMasterVolume = MAX_VOLUME; // 0 - MAX_VOLUME
 
@@ -69,6 +78,10 @@ unsigned int configSkipIntro     = 0;
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configFullscreen},
+    {.name = "window_x",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.x},
+    {.name = "window_y",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.y},
+    {.name = "window_w",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.w},
+    {.name = "window_h",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.h},
     {.name = "texture_filtering",    .type = CONFIG_TYPE_UINT, .uintValue = &configFiltering},
     {.name = "master_volume",        .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "key_a",                .type = CONFIG_TYPE_BIND, .uintValue = configKeyA},

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -41,7 +41,9 @@ ConfigWindow configWindow       = {
     .y = SDL_WINDOWPOS_CENTERED,
     .w = DESIRED_SCREEN_WIDTH,
     .h = DESIRED_SCREEN_HEIGHT,
-    .reset = false
+    .reset = false,
+    .vsync = false,
+    .exiting_fullscreen = false,
 };
 unsigned int configFiltering    = 1;          // 0=force nearest, 1=linear, (TODO) 2=three-point
 unsigned int configMasterVolume = MAX_VOLUME; // 0 - MAX_VOLUME

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -10,6 +10,8 @@
 typedef struct {
     unsigned int x, y, w, h;
     bool reset;
+    bool vsync;
+    bool exiting_fullscreen;
 } ConfigWindow;
 
 extern bool         configFullscreen;

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -7,7 +7,13 @@
 #define MAX_VOLUME   127
 #define VOLUME_SHIFT 7
 
+typedef struct {
+    unsigned int x, y, w, h;
+    bool reset;
+} ConfigWindow;
+
 extern bool         configFullscreen;
+extern ConfigWindow configWindow;
 extern unsigned int configFiltering;
 extern unsigned int configMasterVolume;
 extern unsigned int configKeyA[];

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -11,10 +11,10 @@ typedef struct {
     unsigned int x, y, w, h;
     bool reset;
     bool vsync;
+    bool fullscreen;
     bool exiting_fullscreen;
 } ConfigWindow;
 
-extern bool         configFullscreen;
 extern ConfigWindow configWindow;
 extern unsigned int configFiltering;
 extern unsigned int configMasterVolume;

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -97,9 +97,9 @@ const SDL_Scancode scancode_rmapping_nonextended[][2] = {
 #define IS_FULLSCREEN (SDL_GetWindowFlags(wnd) & SDL_WINDOW_FULLSCREEN_DESKTOP)
 
 static void gfx_sdl_set_fullscreen() {
-    if (configFullscreen == IS_FULLSCREEN)
+    if (configWindow.fullscreen == IS_FULLSCREEN)
         return;
-    if (configFullscreen) {
+    if (configWindow.fullscreen) {
         SDL_SetWindowFullscreen(wnd, SDL_WINDOW_FULLSCREEN_DESKTOP);
         SDL_ShowCursor(SDL_DISABLE);
     } else {
@@ -119,7 +119,10 @@ static void gfx_sdl_reset_dimension_and_pos() {
         configWindow.h = DESIRED_SCREEN_HEIGHT;
         configWindow.reset = false;
 
-        if (IS_FULLSCREEN) return;
+        if (IS_FULLSCREEN) {
+            configWindow.fullscreen = false;
+            return;
+        }
     } else
         return;
 
@@ -161,7 +164,7 @@ static void gfx_sdl_init(void) {
     //SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
 
     if (gCLIOpts.FullScreen)
-        configFullscreen = true;
+        configWindow.fullscreen = true;
 
     const char* window_title = 
     #ifndef USE_GLES
@@ -221,9 +224,9 @@ static void gfx_sdl_onkeydown(int scancode) {
     const Uint8 *state = SDL_GetKeyboardState(NULL);
 
     if (state[SDL_SCANCODE_LALT] && state[SDL_SCANCODE_RETURN])
-        configFullscreen = !configFullscreen;
-    else if (state[SDL_SCANCODE_ESCAPE] && configFullscreen)
-        configFullscreen = false;
+        configWindow.fullscreen = !configWindow.fullscreen;
+    else if (state[SDL_SCANCODE_ESCAPE] && configWindow.fullscreen)
+        configWindow.fullscreen = false;
 }
 
 static void gfx_sdl_onkeyup(int scancode) {


### PR DESCRIPTION
This implements saving the game window position and dimensions in `sm64config.txt` to restore it in later game sessions. Also adds an entry in the options menu (inside the display submenu) to reset the window to the default centered position and dimensions.

Unfortunately, I couldn't make this work when starting the game with `SDL_WINDOW_FULLSCREEN_DESKTOP`. So I put the fullscreen logic after the window initialization, which worked fine, even though it sometimes gives a split-second window resizing animation that didn't use to occur with `SDL_WINDOW_FULLSCREEN_DESKTOP`. If anyone knows how to fix this I would appreciate some help.

~~Also, there's a bug when exiting fullscreen which results in the window being positioned slightly below its original vertical position (this can be easly observed if you enter and exit fullscreen repeatedly). I also couldn't pinpoint the reason for this behavior. Maybe a `SDL_WINDOWEVENT_MOVED` is being triggered during fullscreen exit or something.~~ (FIXED)