### PR TITLE
Added a "super responsive controls" cheat

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -51,6 +51,7 @@
 #define TEXT_OPT_CHEAT3 _("Invincible Mario")
 #define TEXT_OPT_CHEAT4 _("Infinite lives")
 #define TEXT_OPT_CHEAT5 _("Super speed")
+#define TEXT_OPT_CHEAT6 _("Super responsive controls")
 
 /**
  * Global Symbols

--- a/src/game/mario_actions_moving.c
+++ b/src/game/mario_actions_moving.c
@@ -12,6 +12,7 @@
 #include "memory.h"
 #include "behavior_data.h"
 #include "thread6.h"
+#include "pc/configfile.h"
 
 struct LandingAction {
     s16 numFrames;
@@ -461,8 +462,15 @@ void update_walking_speed(struct MarioState *m) {
         m->forwardVel = 48.0f;
     }
 
-    m->faceAngle[1] =
+    /* Handles the "Super responsive controls" cheat. The content of the "else" is Mario's original code for turning around.*/
+
+    if (cheatResponsive == true && cheatEnablecheats == true ) {
+        m->faceAngle[1] = m->intendedYaw;
+    }
+    else {
+         m->faceAngle[1] =
         m->intendedYaw - approach_s32((s16)(m->intendedYaw - m->faceAngle[1]), 0, 0x800, 0x800);
+        }
     apply_slope_accel(m);
 }
 

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -83,6 +83,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT3 },
     { TEXT_OPT_CHEAT4 },
     { TEXT_OPT_CHEAT5 },
+    { TEXT_OPT_CHEAT6 },
 };
 
 static const u8 bindStr[][32] = {
@@ -223,6 +224,7 @@ static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[2], &cheatGodmode ),
     DEF_OPT_TOGGLE( optsCheatsStr[3], &cheatInfinitelives ),
     DEF_OPT_TOGGLE( optsCheatsStr[4], &cheatSuperspeed),
+    DEF_OPT_TOGGLE( optsCheatsStr[5], &cheatResponsive),
 
 };
 

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -43,6 +43,7 @@ bool cheatMoonjump = false;
 bool cheatGodmode = false;
 bool cheatInfinitelives = false;
 bool cheatSuperspeed = false;
+bool cheatResponsive = false;
 
 
 // Keyboard mappings (VK_ values, by default keyboard/gamepad/mouse)

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -24,12 +24,12 @@ extern unsigned int configKeyStickUp[];
 extern unsigned int configKeyStickDown[];
 extern unsigned int configKeyStickLeft[];
 extern unsigned int configKeyStickRight[];
-extern bool cheatMoonjump;
-extern bool cheatGodmode;
-extern bool cheatEnablecheats;
-extern bool cheatInfinitelives;
-extern bool cheatSuperspeed;
-
+extern bool         cheatMoonjump;
+extern bool         cheatGodmode;
+extern bool         cheatEnablecheats;
+extern bool         cheatInfinitelives;
+extern bool         cheatSuperspeed;
+extern bool         cheatResponsive;
 #ifdef BETTERCAMERA
 extern unsigned int configCameraXSens;
 extern unsigned int configCameraYSens;


### PR DESCRIPTION
Added a "super responsive controls" cheat. When enabled, Mario will look straight into the direction the user inputs when changing directions, with no interpolation at all. (you can still slide / side jump / etc )

The change is especially noticeable when playing with keyboard. 