### PR TITLE
Add MSYS2 build fix/simplification

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -30,7 +30,7 @@ aifc_decode_CFLAGS := -O2 # both runs and compiles faster than -O3
 aiff_extract_codebook_SOURCES := aiff_extract_codebook.c
 
 tabledesign_SOURCES := sdk-tools/tabledesign/codebook.c sdk-tools/tabledesign/estimate.c sdk-tools/tabledesign/print.c sdk-tools/tabledesign/tabledesign.c
-tabledesign_CFLAGS := -Wno-uninitialized -laudiofile
+tabledesign_CFLAGS := -Wno-uninitialized -laudiofile -lstdc++
 
 vadpcm_enc_SOURCES := sdk-tools/adpcm/vadpcm_enc.c sdk-tools/adpcm/vpredictor.c sdk-tools/adpcm/quant.c sdk-tools/adpcm/util.c sdk-tools/adpcm/vencode.c
 vadpcm_enc_CFLAGS := -Wno-unused-result -Wno-uninitialized -Wno-sign-compare -Wno-absolute-value


### PR DESCRIPTION
Adds the CFLAG normally added during building in MSYS2 to make MSYS2 builds easier to perform.