### PR TITLE
Fix cleantools and add cleanall (also minor tweak to MXE builds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,13 +217,12 @@ LIBULTRA := $(BUILD_DIR)/libultra.a
 
 ifeq ($(TARGET_WEB),1)
 EXE := $(BUILD_DIR)/$(TARGET).html
-	else ifeq ($(WINDOWS_BUILD),1)
-		EXE := $(BUILD_DIR)/$(TARGET).exe
-	else ifeq ($(TARGET_RPI),1)
-		EXE := $(BUILD_DIR)/$(TARGET).arm
-	else
-		EXE := $(BUILD_DIR)/$(TARGET)
-	endif
+else ifeq ($(WINDOWS_BUILD),1)
+EXE := $(BUILD_DIR)/$(TARGET).exe
+else ifeq ($(TARGET_RPI),1)
+EXE := $(BUILD_DIR)/$(TARGET).arm
+else
+EXE := $(BUILD_DIR)/$(TARGET)
 endif
 
 ELF := $(BUILD_DIR)/$(TARGET).elf

--- a/Makefile.split
+++ b/Makefile.split
@@ -146,11 +146,12 @@ define level_rules =
 endef
 
 ifneq ($(MAKECMDGOALS),clean)
-ifneq ($(MAKECMDGOALS),distclean)
+else ifneq ($(MAKECMDGOALS),distclean)
+else ifneq ($(MAKECMDGOALS),cleantools)
+else ifneq ($(MAKECMDGOALS),cleanall)
 $(BUILD_DIR)/level_rules.mk: levels/level_rules.mk levels/level_defines.h
 	$(CPP) $(VERSION_CFLAGS) -I . -o $@ $<
 include $(BUILD_DIR)/level_rules.mk
-endif
 endif
 
 # --------------------------------------


### PR DESCRIPTION
Fixes https://github.com/sm64pc/sm64pc/issues/152.
`make cleantools` didn't work properly due to incomplete support for it in the makefile. This finishes the support, thereby fixing the bug.
A new option was added called `make cleanall` that combines `make distclean` and `make cleantools` into one command.
MXE also now uses the correct TARGET_ARCH value when building for x64.