### PR TITLE
Fixed Y axis inversion being reversed

### DIFF
--- a/src/game/bettercamera.inc.h
+++ b/src/game/bettercamera.inc.h
@@ -226,9 +226,9 @@ static int ivrt(u8 axis)
     else
     {
         if (newcam_invertY == 0)
-            return 1;
-        else
             return -1;
+        else
+            return 1;
     }
 }
 


### PR DESCRIPTION
"Invert Y Axis: Enabled" would mean non-inverted camera controls, and vice-versa. This commit fixes this.