### PR TITLE
Added cheat: Stay in level after star

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -59,6 +59,7 @@
 #define TEXT_OPT_CHEAT7 _("Exit course at any time")
 #define TEXT_OPT_CHEAT8 _("Huge Mario")
 #define TEXT_OPT_CHEAT9 _("Tiny Mario")
+#define TEXT_OPT_CHEAT10 _("Stay in level after star")
 /**
  * Global Symbols
  */

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -21,6 +21,7 @@
 #include "seq_ids.h"
 #include "course_table.h"
 #include "thread6.h"
+#include "pc/cheats.h"
 
 #define INT_GROUND_POUND_OR_TWIRL (1 << 0) // 0x01
 #define INT_PUNCH                 (1 << 1) // 0x02
@@ -766,6 +767,10 @@ u32 interact_star_or_key(struct MarioState *m, UNUSED u32 interactType, struct O
     u32 starIndex;
     u32 starGrabAction = ACT_STAR_DANCE_EXIT;
     u32 noExit = (o->oInteractionSubtype & INT_SUBTYPE_NO_EXIT) != 0;
+    if (Cheats.StayInLevel == TRUE && Cheats.EnableCheats == TRUE && !(m->controller->buttonDown & L_TRIG) &&
+        !(gCurrLevelNum == LEVEL_BOWSER_1 || gCurrLevelNum == LEVEL_BOWSER_2 || gCurrLevelNum == LEVEL_BOWSER_3)) {
+        noExit = TRUE;
+    }
     u32 grandStar = (o->oInteractionSubtype & INT_SUBTYPE_GRAND_STAR) != 0;
 
     if (m->health >= 0x100) {

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -96,6 +96,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT7 },
     { TEXT_OPT_CHEAT8 },
     { TEXT_OPT_CHEAT9 },
+    { TEXT_OPT_CHEAT10 },
 };
 
 static const u8 bindStr[][32] = {
@@ -257,6 +258,7 @@ static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[6], &Cheats.ExitAnywhere ),
     DEF_OPT_TOGGLE( optsCheatsStr[7], &Cheats.HugeMario ),
     DEF_OPT_TOGGLE( optsCheatsStr[8], &Cheats.TinyMario ),
+    DEF_OPT_TOGGLE( optsCheatsStr[9], &Cheats.StayInLevel ),
 
 };
 

--- a/src/pc/cheats.h
+++ b/src/pc/cheats.h
@@ -13,6 +13,7 @@ struct CheatList {
     bool         ExitAnywhere;
     bool         HugeMario;
     bool         TinyMario;
+    bool         StayInLevel;
 };
 
 extern struct CheatList Cheats;


### PR DESCRIPTION
Added a cheat that makes you stay in a level after collecting a star. You can hold L while collecting a star to temporarily disable this effect and leave the level. This cheat has no effect on Bowser keys, or stars that already make you stay in the level in the base game.

Also, if you have a better name than "Stay in level after star", be my guest. "Stay in level after getting a star (hold L to cancel)" doesn't fit in the cheat description.