### PR TITLE
(Needs Testing) Improve V-Sync and frame-rate synchronization

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -28,7 +28,6 @@
 #define TEXT_OPT_LINEAR    _("Linear")
 #define TEXT_OPT_MVOLUME   _("Master Volume")
 #define TEXT_OPT_VSYNC     _("Vertical Sync")
-#define TEXT_OPT_DOUBLE    _("Double")
 #define TEXT_RESET_WINDOW  _("Reset Window")
 #define TEXT_OPT_HUD       _("HUD")
 

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -78,7 +78,6 @@ static const u8 optsVideoStr[][32] = {
     { TEXT_OPT_LINEAR },
     { TEXT_RESET_WINDOW },
     { TEXT_OPT_VSYNC },
-    { TEXT_OPT_DOUBLE },
     { TEXT_OPT_HUD },
 };
 
@@ -120,12 +119,6 @@ static const u8 bindStr[][32] = {
 static const u8 *filterChoices[] = {
     optsVideoStr[2],
     optsVideoStr[3],
-};
-
-static const u8 *vsyncChoices[] = {
-    toggleStr[0],
-    toggleStr[1],
-    optsVideoStr[6],
 };
 
 enum OptType {
@@ -195,11 +188,7 @@ static void optmenu_act_exit(UNUSED struct Option *self, s32 arg) {
 }
 
 static void optvideo_reset_window(UNUSED struct Option *self, s32 arg) {
-    if (!arg) {
-        // Restrict reset to A press and not directions
-        configWindow.reset = true;
-        configWindow.settings_changed = true;
-    }
+    if (!arg) configWindow.reset = true; // Restrict reset to A press and not directions
 }
 
 /* submenu option lists */
@@ -237,7 +226,7 @@ static struct Option optsControls[] = {
 
 static struct Option optsVideo[] = {
     DEF_OPT_TOGGLE( optsVideoStr[0], &configWindow.fullscreen ),
-    DEF_OPT_CHOICE( optsVideoStr[5], &configWindow.vsync, vsyncChoices ),
+    DEF_OPT_TOGGLE( optsVideoStr[5], &configWindow.vsync ),
     DEF_OPT_CHOICE( optsVideoStr[1], &configFiltering, filterChoices ),
     DEF_OPT_BUTTON( optsVideoStr[4], optvideo_reset_window ),
     DEF_OPT_TOGGLE( optsVideoStr[7], &configHUD ),
@@ -484,7 +473,7 @@ void optmenu_toggle(void) {
 
         currentMenu = &menuMain;
         optmenu_open = 1;
-        
+
         /* Resets l_counter to 0 every time the options menu is open */
         l_counter = 0;
     } else {
@@ -516,7 +505,7 @@ void optmenu_check_buttons(void) {
 
     if (gPlayer1Controller->buttonPressed & R_TRIG)
         optmenu_toggle();
-    
+
     /* Enables cheats if the user press the L trigger 3 times while in the options menu. Also plays a sound. */
     
     if ((gPlayer1Controller->buttonPressed & L_TRIG) && !Cheats.EnableCheats) {
@@ -528,7 +517,7 @@ void optmenu_check_buttons(void) {
             l_counter++;
         }
     }
-    
+
     if (!optmenu_open) return;
 
     u8 allowInput = 0;

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -229,7 +229,7 @@ static struct Option optsVideo[] = {
     DEF_OPT_TOGGLE( optsVideoStr[5], &configWindow.vsync ),
     DEF_OPT_CHOICE( optsVideoStr[1], &configFiltering, filterChoices ),
     DEF_OPT_BUTTON( optsVideoStr[4], optvideo_reset_window ),
-    DEF_OPT_TOGGLE( optsVideoStr[7], &configHUD ),
+    DEF_OPT_TOGGLE( optsVideoStr[6], &configHUD ),
 };
 
 static struct Option optsAudio[] = {

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -36,15 +36,13 @@ struct ConfigOption {
 
 // Video/audio stuff
 ConfigWindow configWindow       = {
-    .x = SDL_WINDOWPOS_CENTERED,
-    .y = SDL_WINDOWPOS_CENTERED,
-    .w = DESIRED_SCREEN_WIDTH,
-    .h = DESIRED_SCREEN_HEIGHT,
-    .vsync = 1,
-    .reset = false,
+    .x          = SDL_WINDOWPOS_CENTERED,
+    .y          = SDL_WINDOWPOS_CENTERED,
+    .w          = DESIRED_SCREEN_WIDTH,
+    .h          = DESIRED_SCREEN_HEIGHT,
+    .reset      = false,
+    .vsync      = true,
     .fullscreen = false,
-    .exiting_fullscreen = false,
-    .settings_changed = false,
 };
 unsigned int configFiltering    = 1;          // 0=force nearest, 1=linear, (TODO) 2=three-point
 unsigned int configMasterVolume = MAX_VOLUME; // 0 - MAX_VOLUME
@@ -86,7 +84,7 @@ static const struct ConfigOption options[] = {
     {.name = "window_y",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.y},
     {.name = "window_w",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.w},
     {.name = "window_h",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.h},
-    {.name = "vsync",                .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.vsync},
+    {.name = "vsync",                .type = CONFIG_TYPE_UINT, .boolValue = &configWindow.vsync},
     {.name = "texture_filtering",    .type = CONFIG_TYPE_UINT, .uintValue = &configFiltering},
     {.name = "master_volume",        .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "key_a",                .type = CONFIG_TYPE_BIND, .uintValue = configKeyA},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -11,11 +11,9 @@
 
 typedef struct {
     unsigned int x, y, w, h;
-    unsigned int vsync;
-    bool reset;
-    bool fullscreen;
-    bool exiting_fullscreen;
-    bool settings_changed;
+    bool         vsync;
+    bool         reset;
+    bool         fullscreen;
 } ConfigWindow;
 
 extern ConfigWindow configWindow;

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -42,6 +42,7 @@
 static struct {
     SDL_GLContext ctx;
     SDL_Window*   wnd;
+    Uint64        frametime;
     int           refresh_rate;
     int           swap_interval;
     bool          exiting_fullscreen;
@@ -252,6 +253,9 @@ static void gfx_sdl_init(void) {
     gfx_sdl_update_vsync();
     gfx_sdl_set_fullscreen();
 
+    // Time that a game's frame should take relative to SDL performance frequency
+    gContext.frametime = SDL_GetPerformanceFrequency() / FRAMERATE;
+
     for (size_t i = 0; i < sizeof(windows_scancode_table) / sizeof(SDL_Scancode); i++) {
         gContext.inverted_scancode_table[windows_scancode_table[i]] = i;
     }
@@ -267,8 +271,6 @@ static void gfx_sdl_init(void) {
 }
 
 static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
-    // Number of nanosecons a game's frame should take
-    const Uint32 FRAMETIME = 1e9 / FRAMERATE;
     Uint64 start, elapsed;
     while (1) {
         start = SDL_GetPerformanceCounter();
@@ -277,7 +279,7 @@ static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
         if (gContext.swap_interval != 0) continue;
 
         elapsed = SDL_GetPerformanceCounter() - start;
-        while (elapsed < FRAMETIME) {
+        while (elapsed < gContext.frametime) {
             SDL_Delay(0);
             elapsed = SDL_GetPerformanceCounter() - start;
         }

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -39,12 +39,14 @@
 # define FRAMERATE 30
 #endif
 
-static const Uint32 FRAME_TIME = 1000 / FRAMERATE;
-
-static SDL_Window *wnd;
-static SDL_GLContext ctx = NULL;
-static int inverted_scancode_table[512];
-static Uint32 frame_start = 0;
+static struct {
+    SDL_GLContext ctx;
+    SDL_Window*   wnd;
+    int           refresh_rate;
+    int           swap_interval;
+    bool          exiting_fullscreen;
+    int           inverted_scancode_table[512];
+} gContext = { 0 };
 
 const SDL_Scancode windows_scancode_table[] =
 {
@@ -97,47 +99,123 @@ const SDL_Scancode scancode_rmapping_nonextended[][2] = {
     {SDL_SCANCODE_KP_MULTIPLY, SDL_SCANCODE_PRINTSCREEN}
 };
 
-#define IS_FULLSCREEN (SDL_GetWindowFlags(wnd) & SDL_WINDOW_FULLSCREEN_DESKTOP)
+#define IS_FULLSCREEN \
+    (SDL_GetWindowFlags(gContext.wnd) & SDL_WINDOW_FULLSCREEN_DESKTOP)
+
+static void gfx_sdl_update_vsync() {
+    static int current_swap_interval = -1;
+
+    if (!configWindow.vsync) {
+        gContext.swap_interval = 0;
+    } else if (
+        gContext.refresh_rate < FRAMERATE || gContext.refresh_rate % FRAMERATE
+    ) {
+        // Soft disable vsync in environemts where display's refresh rate
+        // information is unavailable or it is not a multiple of the game's
+        // fixed framerate
+        if (gContext.swap_interval != 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Vsync is not available");
+            gContext.swap_interval = 0;
+        }
+    } else {
+        gContext.swap_interval = gContext.refresh_rate / FRAMERATE;
+    }
+
+    // Avoid unecessary changes
+    if (gContext.swap_interval == current_swap_interval) return;
+    if (
+        current_swap_interval != -1
+        && current_swap_interval != 0 && gContext.swap_interval != 0
+    ) {
+        // Allow an unsynchronized frame to render to avoid possible jitter
+        // introduced by immediatly changing swap_interval
+        current_swap_interval = 0;
+        SDL_GL_SetSwapInterval(0);
+        SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Jitter fix");
+        return;
+    }
+
+    if (
+        SDL_GL_SetSwapInterval(gContext.swap_interval) && gContext.swap_interval
+    ) {
+        // Failed to set intended swap interval, force disabled vsync
+        configWindow.vsync = false;
+        SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Failed to enable vsync");
+        return gfx_sdl_update_vsync(); // Recurse once to reset vsync
+    }
+
+    // Cache current swap valuez
+    current_swap_interval = gContext.swap_interval;
+
+    if (gContext.swap_interval)
+        SDL_LogDebug(
+            SDL_LOG_CATEGORY_VIDEO, "Vsync enable: %d", gContext.swap_interval
+        );
+    else
+        SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Vsync disabled");
+}
 
 static void gfx_sdl_set_fullscreen() {
     if (configWindow.fullscreen == IS_FULLSCREEN)
         return;
     if (configWindow.fullscreen) {
-        SDL_SetWindowFullscreen(wnd, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        SDL_SetWindowFullscreen(gContext.wnd, SDL_WINDOW_FULLSCREEN_DESKTOP);
         SDL_ShowCursor(SDL_DISABLE);
     } else {
-        SDL_SetWindowFullscreen(wnd, 0);
+        SDL_SetWindowFullscreen(gContext.wnd, 0);
         SDL_ShowCursor(SDL_ENABLE);
-        configWindow.exiting_fullscreen = true;
+        gContext.exiting_fullscreen = true;
     }
 }
 
+static void gfx_sdl_update_refresh_rate() {
+    //! FIXME:
+    // SDL caches the display's current_mode at initialization and only updates
+    // it on explicit SDL mode change calls. So, if any external change happens
+    // it will report wrong values.
+    // Research a way to force SDL to update the display's current_mode on
+    // external changes.
+    // https://stackoverflow.com/questions/39810237/get-the-updated-screen-resolution-in-sdl2
+    SDL_DisplayMode current_display_mode = { 0 };
+    int current_display = SDL_GetWindowDisplayIndex(gContext.wnd);
+    if (current_display < 0
+        || SDL_GetCurrentDisplayMode(current_display, &current_display_mode)
+    ) {
+        // Failed to query display refresh rate, defaults to 0 to disable vsync
+        gContext.refresh_rate = 0;
+        SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Failed to query refresh rate");
+        return;
+    }
+
+    gContext.refresh_rate = current_display_mode.refresh_rate;
+}
+
 static void gfx_sdl_reset_dimension_and_pos() {
-    if (configWindow.exiting_fullscreen) {
-        configWindow.exiting_fullscreen = false;
+    if (gContext.exiting_fullscreen) {
+        gContext.exiting_fullscreen = false;
     } else if (configWindow.reset) {
         configWindow.x = SDL_WINDOWPOS_CENTERED;
         configWindow.y = SDL_WINDOWPOS_CENTERED;
         configWindow.w = DESIRED_SCREEN_WIDTH;
         configWindow.h = DESIRED_SCREEN_HEIGHT;
+        configWindow.vsync = true;
         configWindow.reset = false;
 
         if (IS_FULLSCREEN) {
             configWindow.fullscreen = false;
             return;
         }
-    } else if (!configWindow.settings_changed) {
+    } else {
         return;
     }
 
-    configWindow.settings_changed = false;
-    SDL_SetWindowSize(wnd, configWindow.w, configWindow.h);
-    SDL_SetWindowPosition(wnd, configWindow.x, configWindow.y);
-    SDL_GL_SetSwapInterval(configWindow.vsync); // in case vsync changed
+    SDL_SetWindowSize(gContext.wnd, configWindow.w, configWindow.h);
+    SDL_SetWindowPosition(gContext.wnd, configWindow.x, configWindow.y);
 }
 
 static void gfx_sdl_init(void) {
     SDL_Init(SDL_INIT_VIDEO);
+    SDL_LogSetAllPriority(getenv("DEBUG") ? SDL_LOG_PRIORITY_DEBUG : SDL_LOG_PRIORITY_INFO);
 
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
@@ -163,49 +241,56 @@ static void gfx_sdl_init(void) {
     "Super Mario 64 PC port (OpenGL_ES2)";
     #endif
 
-    wnd = SDL_CreateWindow(
+    gContext.wnd = SDL_CreateWindow(
         window_title,
         configWindow.x, configWindow.y, configWindow.w, configWindow.h,
         SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
     );
-    ctx = SDL_GL_CreateContext(wnd);
+    gContext.ctx = SDL_GL_CreateContext(gContext.wnd);
 
-    SDL_GL_SetSwapInterval(configWindow.vsync);
-
+    gfx_sdl_update_refresh_rate();
+    gfx_sdl_update_vsync();
     gfx_sdl_set_fullscreen();
 
     for (size_t i = 0; i < sizeof(windows_scancode_table) / sizeof(SDL_Scancode); i++) {
-        inverted_scancode_table[windows_scancode_table[i]] = i;
+        gContext.inverted_scancode_table[windows_scancode_table[i]] = i;
     }
 
     for (size_t i = 0; i < sizeof(scancode_rmapping_extended) / sizeof(scancode_rmapping_extended[0]); i++) {
-        inverted_scancode_table[scancode_rmapping_extended[i][0]] = inverted_scancode_table[scancode_rmapping_extended[i][1]] + 0x100;
+        gContext.inverted_scancode_table[scancode_rmapping_extended[i][0]] = gContext.inverted_scancode_table[scancode_rmapping_extended[i][1]] + 0x100;
     }
 
     for (size_t i = 0; i < sizeof(scancode_rmapping_nonextended) / sizeof(scancode_rmapping_nonextended[0]); i++) {
-        inverted_scancode_table[scancode_rmapping_nonextended[i][0]] = inverted_scancode_table[scancode_rmapping_nonextended[i][1]];
-        inverted_scancode_table[scancode_rmapping_nonextended[i][1]] += 0x100;
+        gContext.inverted_scancode_table[scancode_rmapping_nonextended[i][0]] = gContext.inverted_scancode_table[scancode_rmapping_nonextended[i][1]];
+        gContext.inverted_scancode_table[scancode_rmapping_nonextended[i][1]] += 0x100;
     }
 }
 
 static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
-    Uint32 t;
+    // Number of nanosecons a game's frame should take
+    const Uint32 FRAMETIME = 1e9 / FRAMERATE;
+    Uint64 start, elapsed;
     while (1) {
-        t = SDL_GetTicks();
+        start = SDL_GetPerformanceCounter();
         run_one_game_iter();
-        t = SDL_GetTicks() - t;
-        if (t < FRAME_TIME && configWindow.vsync <= 1)
-            SDL_Delay(FRAME_TIME - t);
+
+        if (gContext.swap_interval != 0) continue;
+
+        elapsed = SDL_GetPerformanceCounter() - start;
+        while (elapsed < FRAMETIME) {
+            SDL_Delay(0);
+            elapsed = SDL_GetPerformanceCounter() - start;
+        }
     }
 }
 
 static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
-    SDL_GetWindowSize(wnd, width, height);
+    SDL_GetWindowSize(gContext.wnd, width, height);
 }
 
 static int translate_scancode(int scancode) {
     if (scancode < 512) {
-        return inverted_scancode_table[scancode];
+        return gContext.inverted_scancode_table[scancode];
     } else {
         return 0;
     }
@@ -239,8 +324,10 @@ static void gfx_sdl_handle_events(void) {
                 gfx_sdl_onkeyup(event.key.keysym.scancode);
                 break;
 #endif
-            case SDL_WINDOWEVENT: // TODO: Check if this makes sense to be included in the Web build
-                if (!(IS_FULLSCREEN || configWindow.exiting_fullscreen)) {
+            case SDL_WINDOWEVENT:
+                gfx_sdl_update_refresh_rate();
+                if (!(IS_FULLSCREEN || gContext.exiting_fullscreen)) {
+                    // TODO: Check if this makes sense to be included in the Web build
                     switch (event.window.event) {
                         case SDL_WINDOWEVENT_MOVED:
                             configWindow.x = event.window.data1;
@@ -259,17 +346,17 @@ static void gfx_sdl_handle_events(void) {
         }
     }
 
+    gfx_sdl_update_vsync();
     gfx_sdl_reset_dimension_and_pos();
     gfx_sdl_set_fullscreen();
 }
 
 static bool gfx_sdl_start_frame(void) {
-    frame_start = SDL_GetTicks();
     return true;
 }
 
 static void gfx_sdl_swap_buffers_begin(void) {
-    SDL_GL_SwapWindow(wnd);
+    SDL_GL_SwapWindow(gContext.wnd);
 }
 
 static void gfx_sdl_swap_buffers_end(void) {
@@ -282,8 +369,8 @@ static double gfx_sdl_get_time(void) {
 
 static void gfx_sdl_shutdown(void) {
     if (SDL_WasInit(0)) {
-        if (ctx) { SDL_GL_DeleteContext(ctx); ctx = NULL; }
-        if (wnd) { SDL_DestroyWindow(wnd); wnd = NULL; }
+        if (gContext.ctx) { SDL_GL_DeleteContext(gContext.ctx); gContext.ctx = NULL; }
+        if (gContext.wnd) { SDL_DestroyWindow(gContext.wnd); gContext.wnd = NULL; }
         SDL_Quit();
     }
 }


### PR DESCRIPTION
Hello,

This is a proposed fix for #168 and some improvements for v-sync detection in setups with multiple monitors of heterogeneous refresh-rate.

The changes included are:
 - Automatic detection of current display refresh-rate¹
 - Automatic update of swap-interval to match ratio of display's refresh-rate to game's fixed frame-rate
 - Minor improvement to the precision of frame-rate synchronization (enabled when v-sync is off)
 - Improvement on error handling for environments where SDL can't detect the display frame-rate and/or enable v-sync

> ¹ This has a know bug due to SDL caching the display's current_mode at initialization and only updating it on explicit SDL mode change calls. Therefore, if any external change happens it starts reporting wrong values.