### PR TITLE
Pause on focus loss

### DIFF
--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -45,6 +45,8 @@ ConfigWindow configWindow       = {
     .fullscreen = false,
     .exiting_fullscreen = false,
     .settings_changed = false,
+    .pause_on_focus_lost = false,
+    .focus_lost = false,
 };
 unsigned int configFiltering    = 1;          // 0=force nearest, 1=linear, (TODO) 2=three-point
 unsigned int configMasterVolume = MAX_VOLUME; // 0 - MAX_VOLUME
@@ -88,6 +90,7 @@ static const struct ConfigOption options[] = {
     {.name = "window_h",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.h},
     {.name = "vsync",                .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.vsync},
     {.name = "texture_filtering",    .type = CONFIG_TYPE_UINT, .uintValue = &configFiltering},
+    {.name = "pause_on_focus_lost",  .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.pause_on_focus_lost},
     {.name = "master_volume",        .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "key_a",                .type = CONFIG_TYPE_BIND, .uintValue = configKeyA},
     {.name = "key_b",                .type = CONFIG_TYPE_BIND, .uintValue = configKeyB},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -16,6 +16,8 @@ typedef struct {
     bool fullscreen;
     bool exiting_fullscreen;
     bool settings_changed;
+    bool pause_on_focus_lost;
+    bool focus_lost;
 } ConfigWindow;
 
 extern ConfigWindow configWindow;

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -252,6 +252,14 @@ static void gfx_sdl_handle_events(void) {
                             break;
                     }
                 }
+                switch (event.window.event) {
+                    case SDL_WINDOWEVENT_FOCUS_LOST:
+                        configWindow.focus_lost = true;
+                        break;
+                    case SDL_WINDOWEVENT_FOCUS_GAINED:
+                        configWindow.focus_lost = false;
+                        break;
+                }
                 break;
             case SDL_QUIT:
                 game_exit();

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -57,10 +57,7 @@ void send_display_list(struct SPTask *spTask) {
 
 #define printf
 
-void produce_one_frame(void) {
-    gfx_start_frame();
-    game_loop_one_iteration();
-    
+static void queue_audio(void) {
     int samples_left = audio_api->buffered();
     u32 num_audio_samples = samples_left < audio_api->get_desired_buffered() ? 544 : 528;
     //printf("Audio samples: %d %u\n", samples_left, num_audio_samples);
@@ -80,7 +77,16 @@ void produce_one_frame(void) {
         audio_buffer[i] = ((s32)audio_buffer[i] * mod) >> VOLUME_SHIFT;
 
     audio_api->play((u8*)audio_buffer, 2 * num_audio_samples * 4);
-    
+}
+
+void produce_one_frame(void) {
+    gfx_start_frame();
+
+    if (!(configWindow.pause_on_focus_lost && configWindow.focus_lost)) {
+        game_loop_one_iteration();
+        queue_audio();
+    }
+
     gfx_end_frame();
 }
 


### PR DESCRIPTION
Resolves #191 

This is a PR to add an option to auto pause when window focus is lost. The option currently defaults to false. It will pause the game if the window loses focus, and resume if it regains focus (user clicks on window, or alt-tabs to game). Similarly it works in full-screen mode, if the user alt-tabs out of the game it pauses, and resumes if they alt-tab back.

I also experimented with having the loss of focus result in the game showing the pause menu, as if the player had pressed start, but obviously that only works in game-play, and the game wouldn't pause until cut-scenes, transitions or dialog had finished. If people would rather it behave like that, I can add that instead.