### PR TITLE
Add cheat to bypass key/star save flag checks when opening doors

### DIFF
--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -55,6 +55,7 @@
 #define TEXT_OPT_CHEAT4 _("Infinite lives")
 #define TEXT_OPT_CHEAT5 _("Super speed")
 #define TEXT_OPT_CHEAT6 _("Super responsive controls")
+#define TEXT_OPT_CHEAT7 _("Keyless Entry")
 
 /**
  * Global Symbols

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -1005,7 +1005,6 @@ u32 interact_door(struct MarioState *m, UNUSED u32 interactType, struct Object *
     s16 numStars = save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1);
 
     if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
-
 	if (Cheats.EnableCheats && Cheats.UnlockDoors) {
             u32 actionArg = should_push_or_pull_door(m, o);
             u32 enterDoorAction;

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -21,6 +21,7 @@
 #include "seq_ids.h"
 #include "course_table.h"
 #include "thread6.h"
+#include "pc/cheats.h"
 
 #define INT_GROUND_POUND_OR_TWIRL (1 << 0) // 0x01
 #define INT_PUNCH                 (1 << 1) // 0x02
@@ -904,6 +905,10 @@ u32 interact_warp_door(struct MarioState *m, UNUSED u32 interactType, struct Obj
     u32 actionArg;
 
     if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
+        if (Cheats.EnableCheats && Cheats.UnlockDoors) {
+		goto postdoorcheck;
+	}
+
         if (warpDoorId == 1 && !(saveFlags & SAVE_FLAG_UNLOCKED_UPSTAIRS_DOOR)) {
             if (!(saveFlags & SAVE_FLAG_HAVE_KEY_2)) {
                 if (!sDisplayingDoorText) {
@@ -932,6 +937,8 @@ u32 interact_warp_door(struct MarioState *m, UNUSED u32 interactType, struct Obj
 
             doorAction = ACT_UNLOCKING_KEY_DOOR;
         }
+
+postdoorcheck:
 
         if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
             actionArg = should_push_or_pull_door(m, o) + 0x00000004;
@@ -998,7 +1005,26 @@ u32 interact_door(struct MarioState *m, UNUSED u32 interactType, struct Object *
     s16 numStars = save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1);
 
     if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
-        if (numStars >= requiredNumStars) {
+
+	if (Cheats.EnableCheats && Cheats.UnlockDoors) {
+            u32 actionArg = should_push_or_pull_door(m, o);
+            u32 enterDoorAction;
+
+            if (actionArg & 0x00000001) {
+                enterDoorAction = ACT_PULLING_DOOR;
+            } else {
+                enterDoorAction = ACT_PUSHING_DOOR;
+            }
+
+            m->interactObj = o;
+            m->usedObj = o;
+
+            if (o->oInteractionSubtype & INT_SUBTYPE_STAR_DOOR) {
+                enterDoorAction = ACT_ENTERING_STAR_DOOR;
+            }
+
+            return set_mario_action(m, enterDoorAction, actionArg);
+	} else if (numStars >= requiredNumStars) {
             u32 actionArg = should_push_or_pull_door(m, o);
             u32 enterDoorAction;
             u32 doorSaveFileFlag;

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -88,6 +88,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT4 },
     { TEXT_OPT_CHEAT5 },
     { TEXT_OPT_CHEAT6 },
+    { TEXT_OPT_CHEAT7 },
 };
 
 static const u8 bindStr[][32] = {
@@ -245,6 +246,7 @@ static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[3], &Cheats.InfiniteLives ),
     DEF_OPT_TOGGLE( optsCheatsStr[4], &Cheats.SuperSpeed ),
     DEF_OPT_TOGGLE( optsCheatsStr[5], &Cheats.Responsive ),
+    DEF_OPT_TOGGLE( optsCheatsStr[6], &Cheats.UnlockDoors ),
 
 };
 

--- a/src/pc/cheats.h
+++ b/src/pc/cheats.h
@@ -10,6 +10,7 @@ struct CheatList {
     bool         InfiniteLives;
     bool         SuperSpeed;
     bool         Responsive;
+    bool         UnlockDoors;
 };
 
 extern struct CheatList Cheats;


### PR DESCRIPTION
When the cheat is enabled, Mario will open doors walk through them as though their unlocked save flags had already been raised. This affects all star doors (including the 70 star door, though it doesn't disable the endless staircase) and all keyed doors. Pairs well with --skip-intro if you are looking to quickly debug things without a save file.

Entering the door this way does not affect the save flag, so if you turn off the cheat the door will go back to being locked.

Other cheats I'm considering that go in this same family:
- activate Boos in the courtyard (so you can get to Big Boo's Haunt early)
- move Dire Dire Docks Door
- allow selection of any objective at stage select