### PR TITLE
Add cheat to remove star/key requirements on doors

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -132,6 +132,7 @@
 #define TEXT_OPT_CHEAT7    _("Exit course at any time")
 #define TEXT_OPT_CHEAT8    _("Huge Mario")
 #define TEXT_OPT_CHEAT9    _("Tiny Mario")
+#define TEXT_OPT_CHEAT10   _("No Keys Required")
 
 #endif // VERSION
 

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -21,6 +21,7 @@
 #include "seq_ids.h"
 #include "course_table.h"
 #include "thread6.h"
+#include "pc/cheats.h"
 
 #define INT_GROUND_POUND_OR_TWIRL (1 << 0) // 0x01
 #define INT_PUNCH                 (1 << 1) // 0x02
@@ -904,6 +905,11 @@ u32 interact_warp_door(struct MarioState *m, UNUSED u32 interactType, struct Obj
     u32 actionArg;
 
     if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
+        if (Cheats.EnableCheats && Cheats.UnlockDoors) {
+            /* If the unlock doors cheat is enabled, skip key checks */
+            goto postkeycheck;
+        }
+
         if (warpDoorId == 1 && !(saveFlags & SAVE_FLAG_UNLOCKED_UPSTAIRS_DOOR)) {
             if (!(saveFlags & SAVE_FLAG_HAVE_KEY_2)) {
                 if (!sDisplayingDoorText) {
@@ -933,6 +939,7 @@ u32 interact_warp_door(struct MarioState *m, UNUSED u32 interactType, struct Obj
             doorAction = ACT_UNLOCKING_KEY_DOOR;
         }
 
+postkeycheck:
         if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
             actionArg = should_push_or_pull_door(m, o) + 0x00000004;
 
@@ -998,7 +1005,27 @@ u32 interact_door(struct MarioState *m, UNUSED u32 interactType, struct Object *
     s16 numStars = save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1);
 
     if (m->action == ACT_WALKING || m->action == ACT_DECELERATING) {
-        if (numStars >= requiredNumStars) {
+        if (Cheats.EnableCheats && Cheats.UnlockDoors) {
+            /* If the UnlockDoors Cheat is enabled, it's the same as the approach with >= requiredNumStars,
+             * but never use the action that 'unlocks' the door for the save file */
+            u32 actionArg = should_push_or_pull_door(m, o);
+            u32 enterDoorAction;
+
+            if (actionArg & 0x00000001) {
+                enterDoorAction = ACT_PULLING_DOOR;
+            } else {
+                enterDoorAction = ACT_PUSHING_DOOR;
+            }
+
+            m->interactObj = o;
+            m->usedObj = o;
+
+            if (o->oInteractionSubtype & INT_SUBTYPE_STAR_DOOR) {
+                enterDoorAction = ACT_ENTERING_STAR_DOOR;
+            }
+
+            return set_mario_action(m, enterDoorAction, actionArg);
+        } else if (numStars >= requiredNumStars) {
             u32 actionArg = should_push_or_pull_door(m, o);
             u32 enterDoorAction;
             u32 doorSaveFileFlag;

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -96,6 +96,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT7 },
     { TEXT_OPT_CHEAT8 },
     { TEXT_OPT_CHEAT9 },
+    { TEXT_OPT_CHEAT10 },
 };
 
 static const u8 bindStr[][32] = {
@@ -257,6 +258,7 @@ static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[6], &Cheats.ExitAnywhere ),
     DEF_OPT_TOGGLE( optsCheatsStr[7], &Cheats.HugeMario ),
     DEF_OPT_TOGGLE( optsCheatsStr[8], &Cheats.TinyMario ),
+    DEF_OPT_TOGGLE( optsCheatsStr[9], &Cheats.UnlockDoors ),
 
 };
 

--- a/src/pc/cheats.h
+++ b/src/pc/cheats.h
@@ -13,6 +13,7 @@ struct CheatList {
     bool         ExitAnywhere;
     bool         HugeMario;
     bool         TinyMario;
+    bool         UnlockDoors;
 };
 
 extern struct CheatList Cheats;


### PR DESCRIPTION
I accidentally made a pull request for this feature against master, so here's one against nightly.

Feature is pretty simple. It's a cheat and when it is active you will be able to enter doors that have requirements (stars or keys) without meeting those requirements.

This will open any star door or key door including the 30/50/70 star doors (but it doesn't disable the endless staircase, it just disables the ominous message). It pairs well with --skip-intro to let you quickly get into the game and test something without having to be a master of BLJ skips (even if the simplest one is still helpful for endless stairs).

When you open doors this way, their save flag will not be set, so if you come back later without the cheat they will be locked again. This is even if you meet the requirements with the cheat on... if you meet the requirements then the cheat still skips the part where you actually go through the star/key using animation to open the door as well as the part where it actually sets that save flag.

I notice there is likely to be a merge conflict with another cheat adding patch in review right now, which does make me think maybe this isn't the best way to structure/organize cheat codes. Plus as more and more codes are added it may become worthwhile to come up with a way of categorizing them.