### PR TITLE
Autosave

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -1,0 +1,149 @@
+#ifndef TEXT_OPTIONS_STRINGS_H
+#define TEXT_OPTIONS_STRINGS_H
+
+/* Extended options menu text */
+
+// Menu title strings
+
+#define TEXT_OPT_OPTIONS   _("OPTIONS")
+#define TEXT_OPT_CAMERA    _("CAMERA")
+#define TEXT_OPT_CONTROLS  _("CONTROLS")
+#define TEXT_OPT_VIDEO     _("DISPLAY")
+#define TEXT_OPT_AUDIO     _("SOUND")
+#define TEXT_OPT_OTHER     _("OTHER")
+#define TEXT_OPT_CHEATS    _("CHEATS")
+
+// Markers
+
+#define TEXT_OPT_HIGHLIGHT _("O")
+#define TEXT_OPT_UNBOUND   _("NONE")
+
+// Language specific strings
+
+#if defined(VERSION_JP) || defined(VERSION_SH)
+
+// TODO: Actually translate this to JP
+
+// No . in JP
+
+#define TEXT_OPT_PRESSKEY  _("・・・")
+
+// Option strings
+
+#define TEXT_OPT_BUTTON1   _("Ｒ OPTIONS")
+#define TEXT_OPT_BUTTON2   _("Ｒ RETURN")
+#define TEXT_OPT_ENABLED   _("ENABLED")
+#define TEXT_OPT_DISABLED  _("DISABLED")
+#define TEXT_OPT_CAMX      _("CAMERA X SENSITIVITY")
+#define TEXT_OPT_CAMY      _("CAMERA Y SENSITIVITY")
+#define TEXT_OPT_INVERTX   _("INVERT X AXIS")
+#define TEXT_OPT_INVERTY   _("INVERT Y AXIS")
+#define TEXT_OPT_CAMC      _("CAMERA CENTRE AGGRESSION")
+#define TEXT_OPT_CAMP      _("CAMERA PAN LEVEL")
+#define TEXT_OPT_CAMD      _("CAMERA DECELERATION")
+#define TEXT_OPT_ANALOGUE  _("ANALOGUE CAMERA")
+#define TEXT_OPT_MOUSE     _("MOUSE LOOK")
+#define TEXT_OPT_TEXFILTER _("TEXTURE FILTERING")
+#define TEXT_OPT_FSCREEN   _("FULLSCREEN")
+#define TEXT_OPT_NEAREST   _("NEAREST")
+#define TEXT_OPT_LINEAR    _("LINEAR")
+#define TEXT_OPT_MVOLUME   _("MASTER VOLUME")
+#define TEXT_OPT_VSYNC     _("VERTICAL SYNC")
+#define TEXT_OPT_DOUBLE    _("DOUBLE")
+#define TEXT_RESET_WINDOW  _("RESET WINDOW")
+#define TEXT_OPT_HUD       _("HUD")
+
+#define TEXT_OPT_AUTOSAVE  _("AUTOSAVE")
+#define TEXT_OPT_AUTOSAVE1 _("OFF")
+#define TEXT_OPT_AUTOSAVE2 _("MID-LEVEL ONLY")
+#define TEXT_OPT_AUTOSAVE3 _("ON")
+
+#define TEXT_BIND_A        _("A BUTTON")
+#define TEXT_BIND_B        _("B BUTTON")
+#define TEXT_BIND_START    _("START BUTTON")
+#define TEXT_BIND_L        _("L TRIGGER")
+#define TEXT_BIND_R        _("R TRIGGER")
+#define TEXT_BIND_Z        _("Z TRIGGER")
+#define TEXT_BIND_C_UP     _("C-UP")
+#define TEXT_BIND_C_DOWN   _("C-DOWN")
+#define TEXT_BIND_C_LEFT   _("C-LEFT")
+#define TEXT_BIND_C_RIGHT  _("C-RIGHT")
+#define TEXT_BIND_UP       _("STICK UP")
+#define TEXT_BIND_DOWN     _("STICK DOWN")
+#define TEXT_BIND_LEFT     _("STICK LEFT")
+#define TEXT_BIND_RIGHT    _("STICK RIGHT")
+
+#define TEXT_OPT_CHEAT1    _("ENABLE CHEATS")
+#define TEXT_OPT_CHEAT2    _("MOONJUMP (PRESS L)")
+#define TEXT_OPT_CHEAT3    _("INVINCIBLE MARIO")
+#define TEXT_OPT_CHEAT4    _("INFINITE LIVES")
+#define TEXT_OPT_CHEAT5    _("SUPER SPEED")
+#define TEXT_OPT_CHEAT6    _("SUPER RESPONSIVE CONTROLS")
+#define TEXT_OPT_CHEAT7    _("EXIT COURSE AT ANY TIME")
+#define TEXT_OPT_CHEAT8    _("HUGE MARIO")
+#define TEXT_OPT_CHEAT9    _("TINY MARIO")
+
+#else // VERSION
+
+// Markers
+
+#define TEXT_OPT_PRESSKEY  _("...")
+
+// Option strings
+
+#define TEXT_OPT_BUTTON1   _("[R] Options")
+#define TEXT_OPT_BUTTON2   _("[R] Return")
+#define TEXT_OPT_ENABLED   _("Enabled")
+#define TEXT_OPT_DISABLED  _("Disabled")
+#define TEXT_OPT_CAMX      _("Camera X Sensitivity")
+#define TEXT_OPT_CAMY      _("Camera Y Sensitivity")
+#define TEXT_OPT_INVERTX   _("Invert X Axis")
+#define TEXT_OPT_INVERTY   _("Invert Y Axis")
+#define TEXT_OPT_CAMC      _("Camera Centre Aggression")
+#define TEXT_OPT_CAMP      _("Camera Pan Level")
+#define TEXT_OPT_CAMD      _("Camera Deceleration")
+#define TEXT_OPT_ANALOGUE  _("Analogue Camera")
+#define TEXT_OPT_MOUSE     _("Mouse Look")
+#define TEXT_OPT_TEXFILTER _("Texture Filtering")
+#define TEXT_OPT_FSCREEN   _("Fullscreen")
+#define TEXT_OPT_NEAREST   _("Nearest")
+#define TEXT_OPT_LINEAR    _("Linear")
+#define TEXT_OPT_MVOLUME   _("Master Volume")
+#define TEXT_OPT_VSYNC     _("Vertical Sync")
+#define TEXT_OPT_DOUBLE    _("Double")
+#define TEXT_RESET_WINDOW  _("Reset Window")
+#define TEXT_OPT_HUD       _("HUD")
+
+#define TEXT_OPT_AUTOSAVE  _("Autosave")
+#define TEXT_OPT_AUTOSAVE1 _("Off")
+#define TEXT_OPT_AUTOSAVE2 _("Mid-level only")
+#define TEXT_OPT_AUTOSAVE3 _("On")
+
+#define TEXT_BIND_A        _("A Button")
+#define TEXT_BIND_B        _("B Button")
+#define TEXT_BIND_START    _("Start Button")
+#define TEXT_BIND_L        _("L Trigger")
+#define TEXT_BIND_R        _("R Trigger")
+#define TEXT_BIND_Z        _("Z Trigger")
+#define TEXT_BIND_C_UP     _("C-Up")
+#define TEXT_BIND_C_DOWN   _("C-Down")
+#define TEXT_BIND_C_LEFT   _("C-Left")
+#define TEXT_BIND_C_RIGHT  _("C-Right")
+#define TEXT_BIND_UP       _("Stick Up")
+#define TEXT_BIND_DOWN     _("Stick Down")
+#define TEXT_BIND_LEFT     _("Stick Left")
+#define TEXT_BIND_RIGHT    _("Stick Right")
+
+#define TEXT_OPT_CHEAT1    _("Enable cheats")
+#define TEXT_OPT_CHEAT2    _("Moonjump (Press L)")
+#define TEXT_OPT_CHEAT3    _("Invincible Mario")
+#define TEXT_OPT_CHEAT4    _("Infinite lives")
+#define TEXT_OPT_CHEAT5    _("Super speed")
+#define TEXT_OPT_CHEAT6    _("Super responsive controls")
+#define TEXT_OPT_CHEAT7    _("Exit course at any time")
+#define TEXT_OPT_CHEAT8    _("Huge Mario")
+#define TEXT_OPT_CHEAT9    _("Tiny Mario")
+
+#endif // VERSION
+
+#endif // TEXT_OPTIONS_STRINGS_H

--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -56,7 +56,8 @@
 #define TEXT_OPT_AUTOSAVE  _("AUTOSAVE")
 #define TEXT_OPT_AUTOSAVE1 _("OFF")
 #define TEXT_OPT_AUTOSAVE2 _("MID-LEVEL ONLY")
-#define TEXT_OPT_AUTOSAVE3 _("ON")
+#define TEXT_OPT_AUTOSAVE3 _("END OF LEVEL ONLY")
+#define TEXT_OPT_AUTOSAVE4 _("ON")
 
 #define TEXT_BIND_A        _("A BUTTON")
 #define TEXT_BIND_B        _("B BUTTON")
@@ -116,8 +117,9 @@
 
 #define TEXT_OPT_AUTOSAVE  _("Autosave")
 #define TEXT_OPT_AUTOSAVE1 _("Off")
-#define TEXT_OPT_AUTOSAVE2 _("Mid-level only")
-#define TEXT_OPT_AUTOSAVE3 _("On")
+#define TEXT_OPT_AUTOSAVE2 _("Mid-Level Only")
+#define TEXT_OPT_AUTOSAVE3 _("End of Level Only")
+#define TEXT_OPT_AUTOSAVE4 _("On")
 
 #define TEXT_BIND_A        _("A Button")
 #define TEXT_BIND_B        _("B Button")

--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -19,6 +19,7 @@
 #define TEXT_OPT_CONTROLS  _("CONTROLS")
 #define TEXT_OPT_VIDEO     _("DISPLAY")
 #define TEXT_OPT_AUDIO     _("SOUND")
+#define TEXT_OPT_OTHER     _("OTHER")
 #define TEXT_OPT_HIGHLIGHT _("O")
 #define TEXT_OPT_ANALOGUE  _("Analogue Camera")
 #define TEXT_OPT_MOUSE     _("Mouse Look")
@@ -31,6 +32,11 @@
 #define TEXT_OPT_DOUBLE    _("Double")
 #define TEXT_RESET_WINDOW  _("Reset Window")
 #define TEXT_OPT_HUD       _("HUD")
+
+#define TEXT_OPT_AUTOSAVE  _("Autosave")
+#define TEXT_OPT_AUTOSAVE1 _("Off")
+#define TEXT_OPT_AUTOSAVE2 _("Mid-level only")
+#define TEXT_OPT_AUTOSAVE3 _("On")
 
 #define TEXT_OPT_UNBOUND   _("NONE")
 #define TEXT_OPT_PRESSKEY  _("...")

--- a/include/text_strings.h.in
+++ b/include/text_strings.h.in
@@ -35,8 +35,9 @@
 
 #define TEXT_OPT_AUTOSAVE  _("Autosave")
 #define TEXT_OPT_AUTOSAVE1 _("Off")
-#define TEXT_OPT_AUTOSAVE2 _("Mid-level only")
-#define TEXT_OPT_AUTOSAVE3 _("On")
+#define TEXT_OPT_AUTOSAVE2 _("Mid-Level Only")
+#define TEXT_OPT_AUTOSAVE3 _("End of Level Only")
+#define TEXT_OPT_AUTOSAVE4 _("On")
 
 #define TEXT_OPT_UNBOUND   _("NONE")
 #define TEXT_OPT_PRESSKEY  _("...")

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -3016,7 +3016,7 @@ s16 render_course_complete_screen(void) {
 
     switch (gDialogBoxState) {
         case DIALOG_STATE_OPENING:
-            if (configAutosave == 2) {
+            if (configAutosave == 2 || configAutosave == 3) {
                 level_set_transition(0, 0);
                 gDialogBoxState = DIALOG_STATE_OPENING;
                 gMenuMode = -1;

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -3016,15 +3016,6 @@ s16 render_course_complete_screen(void) {
 
     switch (gDialogBoxState) {
         case DIALOG_STATE_OPENING:
-            render_course_complete_lvl_info_and_hud_str();
-            if (gCourseDoneMenuTimer > 100 && gCourseCompleteCoinsEqual == 1) {
-                gDialogBoxState = DIALOG_STATE_VERTICAL;
-                level_set_transition(-1, 0);
-                gDialogTextAlpha = 0;
-                gDialogLineNum = 1;
-            }
-            break;
-        case DIALOG_STATE_VERTICAL:
             if (configAutosave == 2) {
                 level_set_transition(0, 0);
                 gDialogBoxState = DIALOG_STATE_OPENING;
@@ -3036,15 +3027,23 @@ s16 render_course_complete_screen(void) {
                 gHudFlash = 0;
 
                 return num;
-            } else {
-                shade_screen();
-                render_course_complete_lvl_info_and_hud_str();
-#ifdef VERSION_EU
-                render_save_confirmation(86, &gDialogLineNum, 20);
-#else
-                render_save_confirmation(100, 86, &gDialogLineNum, 20);
-#endif
             }
+            render_course_complete_lvl_info_and_hud_str();
+            if (gCourseDoneMenuTimer > 100 && gCourseCompleteCoinsEqual == 1) {
+                gDialogBoxState = DIALOG_STATE_VERTICAL;
+                level_set_transition(-1, 0);
+                gDialogTextAlpha = 0;
+                gDialogLineNum = 1;
+            }
+            break;
+        case DIALOG_STATE_VERTICAL:
+            shade_screen();
+            render_course_complete_lvl_info_and_hud_str();
+#ifdef VERSION_EU
+            render_save_confirmation(86, &gDialogLineNum, 20);
+#else
+            render_save_confirmation(100, 86, &gDialogLineNum, 20);
+#endif
 
             if (gCourseDoneMenuTimer > 110
                 && (gPlayer3Controller->buttonPressed & A_BUTTON

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -54,6 +54,8 @@ s8 gRedCoinsCollected;
 extern u8 gLastCompletedCourseNum;
 extern u8 gLastCompletedStarNum;
 
+extern bool configEnableAutosave;
+
 enum DialogBoxState {
     DIALOG_STATE_OPENING,
     DIALOG_STATE_VERTICAL,
@@ -3023,13 +3025,26 @@ s16 render_course_complete_screen(void) {
             }
             break;
         case DIALOG_STATE_VERTICAL:
-            shade_screen();
-            render_course_complete_lvl_info_and_hud_str();
+            if (configEnableAutosave == FALSE) {
+                shade_screen();
+                render_course_complete_lvl_info_and_hud_str();
 #ifdef VERSION_EU
-            render_save_confirmation(86, &gDialogLineNum, 20);
+                render_save_confirmation(86, &gDialogLineNum, 20);
 #else
-            render_save_confirmation(100, 86, &gDialogLineNum, 20);
+                render_save_confirmation(100, 86, &gDialogLineNum, 20);
 #endif
+            } else {
+                level_set_transition(0, 0);
+                gDialogBoxState = DIALOG_STATE_OPENING;
+                gMenuMode = -1;
+                num = gDialogLineNum;
+                gCourseDoneMenuTimer = 0;
+                gCourseCompleteCoins = 0;
+                gCourseCompleteCoinsEqual = 0;
+                gHudFlash = 0;
+
+                return num;
+            }
 
             if (gCourseDoneMenuTimer > 110
                 && (gPlayer3Controller->buttonPressed & A_BUTTON

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -54,7 +54,7 @@ s8 gRedCoinsCollected;
 extern u8 gLastCompletedCourseNum;
 extern u8 gLastCompletedStarNum;
 
-extern bool configEnableAutosave;
+extern u16 configAutosave;
 
 enum DialogBoxState {
     DIALOG_STATE_OPENING,
@@ -3025,15 +3025,7 @@ s16 render_course_complete_screen(void) {
             }
             break;
         case DIALOG_STATE_VERTICAL:
-            if (configEnableAutosave == FALSE) {
-                shade_screen();
-                render_course_complete_lvl_info_and_hud_str();
-#ifdef VERSION_EU
-                render_save_confirmation(86, &gDialogLineNum, 20);
-#else
-                render_save_confirmation(100, 86, &gDialogLineNum, 20);
-#endif
-            } else {
+            if (configAutosave == 2) {
                 level_set_transition(0, 0);
                 gDialogBoxState = DIALOG_STATE_OPENING;
                 gMenuMode = -1;
@@ -3044,6 +3036,14 @@ s16 render_course_complete_screen(void) {
                 gHudFlash = 0;
 
                 return num;
+            } else {
+                shade_screen();
+                render_course_complete_lvl_info_and_hud_str();
+#ifdef VERSION_EU
+                render_save_confirmation(86, &gDialogLineNum, 20);
+#else
+                render_save_confirmation(100, 86, &gDialogLineNum, 20);
+#endif
             }
 
             if (gCourseDoneMenuTimer > 110

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1107,6 +1107,7 @@ s32 act_exit_land_save_dialog(struct MarioState *m) {
             if (is_anim_past_end(m)) {
             	if (configAutosave == 2) {
 		            handle_save_menu(m);
+		            cutscene_exit_painting_end(m->area->camera);
 		            break;
             	}
                 if (gLastCompletedCourseNum != COURSE_BITDW

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -30,6 +30,8 @@
 #include "../../include/libc/stdlib.h"
 #include "../pc/pc_main.h"
 
+extern bool configEnableAutosave;
+
 // TODO: put this elsewhere
 enum SaveOption { SAVE_OPT_SAVE_AND_CONTINUE = 1, SAVE_OPT_SAVE_AND_QUIT, SAVE_OPT_SAVE_EXIT_GAME, SAVE_OPT_CONTINUE_DONT_SAVE };
 
@@ -625,8 +627,12 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
                 if ((m->actionArg & 1) == 0) {
                     level_trigger_warp(m, WARP_OP_STAR_EXIT);
                 } else {
-                    enable_time_stop();
-                    create_dialog_box_with_response(gLastCompletedStarNum == 7 ? DIALOG_013 : DIALOG_014);
+                    if (configEnableAutosave == TRUE) {
+                        gLastDialogResponse = 1;
+                    } else {
+                        enable_time_stop();
+                        create_dialog_box_with_response(gLastCompletedStarNum == 7 ? DIALOG_013 : DIALOG_014);
+                    }
                     m->actionState = 1;
                 }
                 break;

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1105,6 +1105,10 @@ s32 act_exit_land_save_dialog(struct MarioState *m) {
             set_mario_animation(m, m->actionArg == 0 ? MARIO_ANIM_GENERAL_LAND
                                                      : MARIO_ANIM_LAND_FROM_SINGLE_JUMP);
             if (is_anim_past_end(m)) {
+            	if (configAutosave == 2) {
+		            handle_save_menu(m);
+		            break;
+            	}
                 if (gLastCompletedCourseNum != COURSE_BITDW
                     && gLastCompletedCourseNum != COURSE_BITFS) {
                     enable_time_stop();

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -256,7 +256,7 @@ void handle_save_menu(struct MarioState *m) {
     s32 dialogID;
     // wait for the menu to show up
     // mario_finished_animation(m) ? (not my file, not my problem)
-    if (configAutosave == 2) {
+    if (configAutosave == 2 || configAutosave == 3) {
     	gSaveOptSelectIndex = SAVE_OPT_SAVE_AND_CONTINUE;
     }
     if (is_anim_past_end(m) && gSaveOptSelectIndex != 0) {
@@ -630,7 +630,7 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
                 if ((m->actionArg & 1) == 0) {
                     level_trigger_warp(m, WARP_OP_STAR_EXIT);
                 } else {
-                    if (configAutosave > 0) {
+                    if (configAutosave == 1 || configAutosave == 3) {
                         gDialogResponse = 1;
                     } else {
                         enable_time_stop();
@@ -1105,7 +1105,7 @@ s32 act_exit_land_save_dialog(struct MarioState *m) {
             set_mario_animation(m, m->actionArg == 0 ? MARIO_ANIM_GENERAL_LAND
                                                      : MARIO_ANIM_LAND_FROM_SINGLE_JUMP);
             if (is_anim_past_end(m)) {
-            	if (configAutosave == 2) {
+            	if (configAutosave == 2 || configAutosave == 3) {
 		            handle_save_menu(m);
 		            cutscene_exit_painting_end(m->area->camera);
 		            break;

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -30,7 +30,7 @@
 #include "../../include/libc/stdlib.h"
 #include "../pc/pc_main.h"
 
-extern bool configEnableAutosave;
+extern u16 configAutosave;
 
 // TODO: put this elsewhere
 enum SaveOption { SAVE_OPT_SAVE_AND_CONTINUE = 1, SAVE_OPT_SAVE_AND_QUIT, SAVE_OPT_SAVE_EXIT_GAME, SAVE_OPT_CONTINUE_DONT_SAVE };
@@ -256,7 +256,7 @@ void handle_save_menu(struct MarioState *m) {
     s32 dialogID;
     // wait for the menu to show up
     // mario_finished_animation(m) ? (not my file, not my problem)
-    if (configEnableAutosave == TRUE) {
+    if (configAutosave == 2) {
     	gSaveOptSelectIndex = SAVE_OPT_SAVE_AND_CONTINUE;
     }
     if (is_anim_past_end(m) && gSaveOptSelectIndex != 0) {
@@ -630,7 +630,7 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
                 if ((m->actionArg & 1) == 0) {
                     level_trigger_warp(m, WARP_OP_STAR_EXIT);
                 } else {
-                    if (configEnableAutosave == TRUE) {
+                    if (configAutosave > 0) {
                         gDialogResponse = 1;
                     } else {
                         enable_time_stop();

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -256,6 +256,9 @@ void handle_save_menu(struct MarioState *m) {
     s32 dialogID;
     // wait for the menu to show up
     // mario_finished_animation(m) ? (not my file, not my problem)
+    if (configEnableAutosave == TRUE) {
+    	gSaveOptSelectIndex = SAVE_OPT_SAVE_AND_CONTINUE;
+    }
     if (is_anim_past_end(m) && gSaveOptSelectIndex != 0) {
         // save and continue / save and quit
         if (gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_CONTINUE || gSaveOptSelectIndex == SAVE_OPT_SAVE_EXIT_GAME || gSaveOptSelectIndex == SAVE_OPT_SAVE_AND_QUIT) {
@@ -628,7 +631,7 @@ void general_star_dance_handler(struct MarioState *m, s32 isInWater) {
                     level_trigger_warp(m, WARP_OP_STAR_EXIT);
                 } else {
                     if (configEnableAutosave == TRUE) {
-                        gLastDialogResponse = 1;
+                        gDialogResponse = 1;
                     } else {
                         enable_time_stop();
                         create_dialog_box_with_response(gLastCompletedStarNum == 7 ? DIALOG_013 : DIALOG_014);

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -92,6 +92,7 @@ static const u8 optsAutosaveStr[][32] = {
     { TEXT_OPT_AUTOSAVE1 },
     { TEXT_OPT_AUTOSAVE2 },
     { TEXT_OPT_AUTOSAVE3 },
+    { TEXT_OPT_AUTOSAVE4 },
 };
 
 static const u8 optsCheatsStr[][64] = {
@@ -140,6 +141,7 @@ static const u8 *autosaveChoices[] = {
     optsAutosaveStr[1],
     optsAutosaveStr[2],
     optsAutosaveStr[3],
+    optsAutosaveStr[4],
 };
 
 enum OptType {

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -54,6 +54,7 @@ static const u8 menuStr[][32] = {
     { TEXT_OPT_CONTROLS },
     { TEXT_OPT_VIDEO },
     { TEXT_OPT_AUDIO },
+    { TEXT_OPT_OTHER },
     { TEXT_EXIT_GAME },
     { TEXT_OPT_CHEATS },
 
@@ -84,6 +85,13 @@ static const u8 optsVideoStr[][32] = {
 
 static const u8 optsAudioStr[][32] = {
     { TEXT_OPT_MVOLUME },
+};
+
+static const u8 optsAutosaveStr[][32] = {
+    { TEXT_OPT_AUTOSAVE },
+    { TEXT_OPT_AUTOSAVE1 },
+    { TEXT_OPT_AUTOSAVE2 },
+    { TEXT_OPT_AUTOSAVE3 },
 };
 
 static const u8 optsCheatsStr[][64] = {
@@ -126,6 +134,12 @@ static const u8 *vsyncChoices[] = {
     toggleStr[0],
     toggleStr[1],
     optsVideoStr[6],
+};
+
+static const u8 *autosaveChoices[] = {
+    optsAutosaveStr[1],
+    optsAutosaveStr[2],
+    optsAutosaveStr[3],
 };
 
 enum OptType {
@@ -247,6 +261,10 @@ static struct Option optsAudio[] = {
     DEF_OPT_SCROLL( optsAudioStr[0], &configMasterVolume, 0, MAX_VOLUME, 1 ),
 };
 
+static struct Option optsOther[] = {
+    DEF_OPT_CHOICE( optsAutosaveStr[0], &configAutosave, autosaveChoices ),
+};
+
 static struct Option optsCheats[] = {
     DEF_OPT_TOGGLE( optsCheatsStr[0], &Cheats.EnableCheats ),
     DEF_OPT_TOGGLE( optsCheatsStr[1], &Cheats.MoonJump ),
@@ -268,7 +286,8 @@ static struct SubMenu menuCamera   = DEF_SUBMENU( menuStr[4], optsCamera );
 static struct SubMenu menuControls = DEF_SUBMENU( menuStr[5], optsControls );
 static struct SubMenu menuVideo    = DEF_SUBMENU( menuStr[6], optsVideo );
 static struct SubMenu menuAudio    = DEF_SUBMENU( menuStr[7], optsAudio );
-static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[9], optsCheats );
+static struct SubMenu menuOther    = DEF_SUBMENU( menuStr[8], optsOther );
+static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[10], optsCheats );
 
 /* main options menu definition */
 
@@ -279,9 +298,10 @@ static struct Option optsMain[] = {
     DEF_OPT_SUBMENU( menuStr[5], &menuControls ),
     DEF_OPT_SUBMENU( menuStr[6], &menuVideo ),
     DEF_OPT_SUBMENU( menuStr[7], &menuAudio ),
-    DEF_OPT_BUTTON ( menuStr[8], optmenu_act_exit ),
+    DEF_OPT_SUBMENU( menuStr[8], &menuOther ),
+    DEF_OPT_BUTTON ( menuStr[9], optmenu_act_exit ),
     // NOTE: always keep cheats the last option here because of the half-assed way I toggle them
-    DEF_OPT_SUBMENU( menuStr[9], &menuCheats )
+    DEF_OPT_SUBMENU( menuStr[10], &menuCheats )
 };
 
 static struct SubMenu menuMain = DEF_SUBMENU( menuStr[3], optsMain );

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -67,19 +67,19 @@ unsigned int configKeyStickRight[MAX_BINDS] = { 0x0020,   VK_INVALID, VK_INVALID
 
 #ifdef BETTERCAMERA
 // BetterCamera settings
-unsigned int configCameraXSens    = 50;
-unsigned int configCameraYSens    = 50;
-unsigned int configCameraAggr     = 0;
-unsigned int configCameraPan      = 0;
-unsigned int configCameraDegrade  = 10; // 0 - 100%
-bool         configCameraInvertX  = true;
-bool         configCameraInvertY  = false;
-bool         configEnableCamera   = false;
-bool         configCameraMouse    = false;
+unsigned int configCameraXSens   = 50;
+unsigned int configCameraYSens   = 50;
+unsigned int configCameraAggr    = 0;
+unsigned int configCameraPan     = 0;
+unsigned int configCameraDegrade = 10; // 0 - 100%
+bool         configCameraInvertX = true;
+bool         configCameraInvertY = false;
+bool         configEnableCamera  = false;
+bool         configCameraMouse   = false;
 #endif
-unsigned int configSkipIntro      = 0;
-bool         configHUD            = true;
-unsigned int configAutosave       = 0;        // 0=off, 1=mid-level only, 2=on
+unsigned int configSkipIntro     = 0;
+bool         configHUD           = true;
+unsigned int configAutosave      = 0;        // 0=off, 1=mid-level only, 2=on
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.fullscreen},

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -79,7 +79,7 @@ bool         configCameraMouse    = false;
 #endif
 unsigned int configSkipIntro      = 0;
 bool         configHUD            = true;
-bool         configEnableAutosave = false;
+unsigned int configAutosave       = 0;        // 0=off, 1=mid-level only, 2=on
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.fullscreen},
@@ -116,7 +116,7 @@ static const struct ConfigOption options[] = {
     {.name = "bettercam_degrade",    .type = CONFIG_TYPE_UINT, .uintValue = &configCameraDegrade},
     #endif
     {.name = "skip_intro",           .type = CONFIG_TYPE_UINT, .uintValue = &configSkipIntro},    // Add this back!
-    {.name = "autosave_enable",      .type = CONFIG_TYPE_BOOL, .uintValue = &configEnableAutosave},
+    {.name = "autosave",             .type = CONFIG_TYPE_UINT, .uintValue = &configAutosave},
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -79,7 +79,7 @@ bool         configCameraMouse   = false;
 #endif
 unsigned int configSkipIntro     = 0;
 bool         configHUD           = true;
-unsigned int configAutosave      = 0;        // 0=off, 1=mid-level only, 2=on
+unsigned int configAutosave      = 0;        // 0=off, 1=mid-level only, 2=end of level only, 3=on
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.fullscreen},

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -67,18 +67,19 @@ unsigned int configKeyStickRight[MAX_BINDS] = { 0x0020,   VK_INVALID, VK_INVALID
 
 #ifdef BETTERCAMERA
 // BetterCamera settings
-unsigned int configCameraXSens   = 50;
-unsigned int configCameraYSens   = 50;
-unsigned int configCameraAggr    = 0;
-unsigned int configCameraPan     = 0;
-unsigned int configCameraDegrade = 10; // 0 - 100%
-bool         configCameraInvertX = true;
-bool         configCameraInvertY = false;
-bool         configEnableCamera  = false;
-bool         configCameraMouse   = false;
+unsigned int configCameraXSens    = 50;
+unsigned int configCameraYSens    = 50;
+unsigned int configCameraAggr     = 0;
+unsigned int configCameraPan      = 0;
+unsigned int configCameraDegrade  = 10; // 0 - 100%
+bool         configCameraInvertX  = true;
+bool         configCameraInvertY  = false;
+bool         configEnableCamera   = false;
+bool         configCameraMouse    = false;
 #endif
-unsigned int configSkipIntro     = 0;
-bool         configHUD           = true;
+unsigned int configSkipIntro      = 0;
+bool         configHUD            = true;
+bool         configEnableAutosave = false;
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",           .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.fullscreen},
@@ -115,6 +116,7 @@ static const struct ConfigOption options[] = {
     {.name = "bettercam_degrade",    .type = CONFIG_TYPE_UINT, .uintValue = &configCameraDegrade},
     #endif
     {.name = "skip_intro",           .type = CONFIG_TYPE_UINT, .uintValue = &configSkipIntro},    // Add this back!
+    {.name = "autosave_enable",      .type = CONFIG_TYPE_BOOL, .uintValue = &configEnableAutosave},
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -47,6 +47,7 @@ extern bool         configEnableCamera;
 extern bool         configCameraMouse;
 #endif
 extern bool         configHUD;
+extern unsigned int configAutosave;
 
 void configfile_load(const char *filename);
 void configfile_save(const char *filename);


### PR DESCRIPTION
Added an "Other" section to the Options menu, and added an Autosave feature to this section. The possible options are:

**Off**
- No effect

**Mid-level only**
- Removes mid-level dialog box when you get a star (like "Wow! Another power star!" or "You got 8 red coins [in a Bowser level]!") and saves the game immediately after the star animation.

**End of Level Only**
- Getting a star that kicks you out of the level skips the coin tally, animation of Mario taking his hat off, Save screen, etc. In other words, the game saves and you can start moving as soon as you exit the level.

**On**
- Combines the previous two options into one.