### PR TITLE
Increased delay between star selection and level load

### DIFF
--- a/levels/menu/script.c
+++ b/levels/menu/script.c
@@ -88,7 +88,7 @@ const LevelScript level_main_menu_entry_2[] = {
     /*37*/ TRANSITION(/*transType*/ WARP_TRANSITION_FADE_INTO_COLOR, /*time*/ 16, /*color*/ 0xFF, 0xFF, 0xFF),
     /*39*/ SLEEP(/*frames*/ 16),
     /*40*/ CLEAR_LEVEL(),
-    /*41*/ SLEEP_BEFORE_EXIT(/*frames*/ 1),
+    /*41*/ SLEEP_BEFORE_EXIT(/*frames*/ 9),
     // L1:
     /*42*/ EXIT(),
 };


### PR DESCRIPTION
A small PR that increases the delay after selecting a star, so now you can hear "Let's-a go" and the sound effect that goes with it without them cutting out early.