### PR TITLE
Added joystick deadzone setting to Controls

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -66,6 +66,7 @@
 #define TEXT_BIND_DOWN     _("STICK DOWN")
 #define TEXT_BIND_LEFT     _("STICK LEFT")
 #define TEXT_BIND_RIGHT    _("STICK RIGHT")
+#define TEXT_OPT_DEADZONE  _("STICK DEADZONE")
 
 #define TEXT_OPT_CHEAT1    _("ENABLE CHEATS")
 #define TEXT_OPT_CHEAT2    _("MOONJUMP (PRESS L)")
@@ -122,6 +123,7 @@
 #define TEXT_BIND_DOWN     _("Stick Down")
 #define TEXT_BIND_LEFT     _("Stick Left")
 #define TEXT_BIND_RIGHT    _("Stick Right")
+#define TEXT_OPT_DEADZONE  _("Stick Deadzone")
 
 #define TEXT_OPT_CHEAT1    _("Enable cheats")
 #define TEXT_OPT_CHEAT2    _("Moonjump (Press L)")

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -115,6 +115,7 @@ static const u8 bindStr[][32] = {
     { TEXT_BIND_DOWN },
     { TEXT_BIND_LEFT },
     { TEXT_BIND_RIGHT },
+    { TEXT_OPT_DEADZONE },
 };
 
 static const u8 *filterChoices[] = {
@@ -233,6 +234,9 @@ static struct Option optsControls[] = {
     DEF_OPT_BIND( bindStr[13], configKeyStickDown ),
     DEF_OPT_BIND( bindStr[14], configKeyStickLeft ),
     DEF_OPT_BIND( bindStr[15], configKeyStickRight ),
+    // max deadzone is 31000; this is less than the max range of 32768, but this
+    // way, the player can't accidentally lock themselves out of using the stick
+    DEF_OPT_SCROLL( bindStr[16], &configStickDeadzone, 0, 100, 1 ),
 };
 
 static struct Option optsVideo[] = {

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -234,7 +234,7 @@ static struct Option optsControls[] = {
     DEF_OPT_BIND( bindStr[13], configKeyStickDown ),
     DEF_OPT_BIND( bindStr[14], configKeyStickLeft ),
     DEF_OPT_BIND( bindStr[15], configKeyStickRight ),
-    // max deadzone is 31000; this is less than the max range of 32768, but this
+    // max deadzone is 31000; this is less than the max range of ~32768, but this
     // way, the player can't accidentally lock themselves out of using the stick
     DEF_OPT_SCROLL( bindStr[16], &configStickDeadzone, 0, 100, 1 ),
 };

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -66,6 +66,7 @@ unsigned int configKeyStickUp[MAX_BINDS]    = { 0x0011,   VK_INVALID, VK_INVALID
 unsigned int configKeyStickDown[MAX_BINDS]  = { 0x001F,   VK_INVALID, VK_INVALID };
 unsigned int configKeyStickLeft[MAX_BINDS]  = { 0x001E,   VK_INVALID, VK_INVALID };
 unsigned int configKeyStickRight[MAX_BINDS] = { 0x0020,   VK_INVALID, VK_INVALID };
+unsigned int configStickDeadzone = 16; // 16*DEADZONE_STEP=4960 (the original default deadzone)
 #ifdef EXTERNAL_TEXTURES
 bool configPrecacheRes = false;
 #endif
@@ -107,6 +108,7 @@ static const struct ConfigOption options[] = {
     {.name = "key_stickdown",        .type = CONFIG_TYPE_BIND, .uintValue = configKeyStickDown},
     {.name = "key_stickleft",        .type = CONFIG_TYPE_BIND, .uintValue = configKeyStickLeft},
     {.name = "key_stickright",       .type = CONFIG_TYPE_BIND, .uintValue = configKeyStickRight},
+    {.name = "stick_deadzone",       .type = CONFIG_TYPE_UINT, .uintValue = &configStickDeadzone},
     #ifdef EXTERNAL_TEXTURES
     {.name = "precache",             .type = CONFIG_TYPE_BOOL, .boolValue = &configPrecacheRes},
     #endif

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -35,6 +35,7 @@ extern unsigned int configKeyStickUp[];
 extern unsigned int configKeyStickDown[];
 extern unsigned int configKeyStickLeft[];
 extern unsigned int configKeyStickRight[];
+extern unsigned int configStickDeadzone;
 #ifdef EXTERNAL_TEXTURES
 extern bool         configPrecacheRes;
 #endif

--- a/src/pc/controller/controller_api.h
+++ b/src/pc/controller/controller_api.h
@@ -1,7 +1,7 @@
 #ifndef CONTROLLER_API
 #define CONTROLLER_API
 
-#define DEADZONE 4960
+#define DEADZONE_STEP 310         // original deadzone is 4960
 #define VK_INVALID 0xFFFF
 #define VK_SIZE 0x1000
 

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -40,7 +40,8 @@ void osContGetReadData(OSContPad *pad) {
 
 #ifdef BETTERCAMERA
     uint32_t magnitude_sq = (uint32_t)(rightx * rightx) + (uint32_t)(righty * righty);
-    if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
+    uint32_t stickDeadzoneActual = configStickDeadzone * DEADZONE_STEP;
+    if (magnitude_sq > (uint32_t)(stickDeadzoneActual * stickDeadzoneActual)) {
         c_rightx = rightx / 0x100;
         int stick_y = -righty / 0x100;
         c_righty = stick_y == 128 ? 127 : stick_y;

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -182,7 +182,8 @@ static void controller_sdl_read(OSContPad *pad) {
     if (rtrig > 30 * 256) pad->button |= R_TRIG;
 
     uint32_t magnitude_sq = (uint32_t)(leftx * leftx) + (uint32_t)(lefty * lefty);
-    if (magnitude_sq > (uint32_t)(DEADZONE * DEADZONE)) {
+    uint32_t stickDeadzoneActual = configStickDeadzone * DEADZONE_STEP;
+    if (magnitude_sq > (uint32_t)(stickDeadzoneActual * stickDeadzoneActual)) {
         pad->stick_x = leftx / 0x100;
         int stick_y = -lefty / 0x100;
         pad->stick_y = stick_y == 128 ? 127 : stick_y;


### PR DESCRIPTION
Added a setting to the Controls menu that lets you change the stick deadzone.

The original default deadzone is 4960 with the max being around 32768. This menu changes the deadzone in increments of 310, so the default setting is 16 out of 100. This would make the max deadzone 31000, which gives the player some room so they don't accidentally lock themselves out of using the stick (besides, no one's going to set the deadzone that high).

This also removes the DEADZONE define in src/pc/controller_api.h since it's no longer used.