### PR TITLE
Fixed fish constantly respawning with NODRAWINGDISTANCE=1

### DIFF
--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -62,11 +62,13 @@ void fish_act_spawn(void) {
  * Y coordinate is greater than 2000.0f then spawn another fish.
  */
 void fish_act_respawn(void) {
+#ifndef NODRAWINGDISTANCE
     if (gCurrLevelNum != LEVEL_SA) {
         if (gMarioObject->oPosY - o->oPosY > 2000.0f) {
             o->oAction = FISH_ACT_RESPAWN;
         }
     }
+#endif
 }
 
 /**


### PR DESCRIPTION
When NODRAWINGDISTANCE is enabled and Mario is outside the normal fish viewing range, fish constantly despawn and respawn, making them warp all over the place. This fixes that behavior.