### PR TITLE
Remove windowed mode on ESC

### DIFF
--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -222,8 +222,6 @@ static void gfx_sdl_onkeydown(int scancode) {
 
     if (state[SDL_SCANCODE_LALT] && state[SDL_SCANCODE_RETURN])
         configWindow.fullscreen = !configWindow.fullscreen;
-    else if (state[SDL_SCANCODE_ESCAPE] && configWindow.fullscreen)
-        configWindow.fullscreen = false;
 }
 
 static void gfx_sdl_onkeyup(int scancode) {


### PR DESCRIPTION
Since we now have an in-game fullscreen toggle, we no longer need an alternative keybind to enter windowed mode than alt+enter.