### PR TITLE
Option Menu Changes

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -14,7 +14,8 @@
 
 // Markers
 
-#define TEXT_OPT_HIGHLIGHT _("O")
+#define TEXT_OPT_L_HIGHLIGHT _(">")
+#define TEXT_OPT_R_HIGHLIGHT _("<")
 #define TEXT_OPT_UNBOUND   _("NONE")
 
 // Language specific strings

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -35,7 +35,7 @@ static s32 l_counter = 0;
 
 // How to add stuff:
 // strings: add them to include/text_strings.h.in
-//          and to optMainStr[] / opts*Str[]
+//          and to menuStr[] / opts*Str[]
 // options: add them to the relevant options list
 // menus:   add a new submenu definition and a new
 //          option to the optsMain list
@@ -52,7 +52,7 @@ static const u8 optSmallStr[][32] = {
     { TEXT_OPT_R_HIGHLIGHT },
 };
 
-static const u8 optMainStr[][32] = {
+static const u8 menuStr[][32] = {
     { TEXT_OPT_OPTIONS },
     { TEXT_OPT_CAMERA },
     { TEXT_OPT_CONTROLS },
@@ -107,7 +107,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT9 },
 };
 
-static const u8 optBindStr[][32] = {
+static const u8 bindStr[][32] = {
     { TEXT_OPT_UNBOUND },
     { TEXT_OPT_PRESSKEY },
     { TEXT_BIND_A },
@@ -236,24 +236,24 @@ static struct Option optsCamera[] = {
 #endif
 
 static struct Option optsControls[] = {
-    DEF_OPT_BIND( optBindStr[ 2], configKeyA ),
-    DEF_OPT_BIND( optBindStr[ 3], configKeyB ),
-    DEF_OPT_BIND( optBindStr[ 4], configKeyStart ),
-    DEF_OPT_BIND( optBindStr[ 5], configKeyL ),
-    DEF_OPT_BIND( optBindStr[ 6], configKeyR ),
-    DEF_OPT_BIND( optBindStr[ 7], configKeyZ ),
-    DEF_OPT_BIND( optBindStr[ 8], configKeyCUp ),
-    DEF_OPT_BIND( optBindStr[ 9], configKeyCDown ),
-    DEF_OPT_BIND( optBindStr[10], configKeyCLeft ),
-    DEF_OPT_BIND( optBindStr[11], configKeyCRight ),
-    DEF_OPT_BIND( optBindStr[12], configKeyStickUp ),
-    DEF_OPT_BIND( optBindStr[13], configKeyStickDown ),
-    DEF_OPT_BIND( optBindStr[14], configKeyStickLeft ),
-    DEF_OPT_BIND( optBindStr[15], configKeyStickRight ),
+    DEF_OPT_BIND( bindStr[ 2], configKeyA ),
+    DEF_OPT_BIND( bindStr[ 3], configKeyB ),
+    DEF_OPT_BIND( bindStr[ 4], configKeyStart ),
+    DEF_OPT_BIND( bindStr[ 5], configKeyL ),
+    DEF_OPT_BIND( bindStr[ 6], configKeyR ),
+    DEF_OPT_BIND( bindStr[ 7], configKeyZ ),
+    DEF_OPT_BIND( bindStr[ 8], configKeyCUp ),
+    DEF_OPT_BIND( bindStr[ 9], configKeyCDown ),
+    DEF_OPT_BIND( bindStr[10], configKeyCLeft ),
+    DEF_OPT_BIND( bindStr[11], configKeyCRight ),
+    DEF_OPT_BIND( bindStr[12], configKeyStickUp ),
+    DEF_OPT_BIND( bindStr[13], configKeyStickDown ),
+    DEF_OPT_BIND( bindStr[14], configKeyStickLeft ),
+    DEF_OPT_BIND( bindStr[15], configKeyStickRight ),
     // max deadzone is 31000; this is less than the max range of ~32768, but this
     // way, the player can't accidentally lock themselves out of using the stick
-    DEF_OPT_SCROLL( optBindStr[16], &configStickDeadzone, 0, 100, 1 ),
-    DEF_OPT_SCROLL( optBindStr[17], &configRumbleStrength, 0, 100, 1)
+    DEF_OPT_SCROLL( bindStr[16], &configStickDeadzone, 0, 100, 1 ),
+    DEF_OPT_SCROLL( bindStr[17], &configRumbleStrength, 0, 100, 1)
 };
 
 static struct Option optsVideo[] = {
@@ -288,28 +288,28 @@ static struct Option optsCheats[] = {
 /* submenu definitions */
 
 #ifdef BETTERCAMERA
-static struct SubMenu menuCamera   = DEF_SUBMENU( optMainStr[1], optsCamera );
+static struct SubMenu menuCamera   = DEF_SUBMENU( menuStr[1], optsCamera );
 #endif
-static struct SubMenu menuControls = DEF_SUBMENU( optMainStr[2], optsControls );
-static struct SubMenu menuVideo    = DEF_SUBMENU( optMainStr[3], optsVideo );
-static struct SubMenu menuAudio    = DEF_SUBMENU( optMainStr[4], optsAudio );
-static struct SubMenu menuCheats   = DEF_SUBMENU( optMainStr[6], optsCheats );
+static struct SubMenu menuControls = DEF_SUBMENU( menuStr[2], optsControls );
+static struct SubMenu menuVideo    = DEF_SUBMENU( menuStr[3], optsVideo );
+static struct SubMenu menuAudio    = DEF_SUBMENU( menuStr[4], optsAudio );
+static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[6], optsCheats );
 
 /* main options menu definition */
 
 static struct Option optsMain[] = {
 #ifdef BETTERCAMERA
-    DEF_OPT_SUBMENU( optMainStr[1], &menuCamera ),
+    DEF_OPT_SUBMENU( menuStr[1], &menuCamera ),
 #endif
-    DEF_OPT_SUBMENU( optMainStr[2], &menuControls ),
-    DEF_OPT_SUBMENU( optMainStr[3], &menuVideo ),
-    DEF_OPT_SUBMENU( optMainStr[4], &menuAudio ),
-    DEF_OPT_BUTTON ( optMainStr[5], optmenu_act_exit ),
+    DEF_OPT_SUBMENU( menuStr[2], &menuControls ),
+    DEF_OPT_SUBMENU( menuStr[3], &menuVideo ),
+    DEF_OPT_SUBMENU( menuStr[4], &menuAudio ),
+    DEF_OPT_BUTTON ( menuStr[5], optmenu_act_exit ),
     // NOTE: always keep cheats the last option here because of the half-assed way I toggle them
-    DEF_OPT_SUBMENU( optMainStr[6], &menuCheats )
+    DEF_OPT_SUBMENU( menuStr[6], &menuCheats )
 };
 
-static struct SubMenu menuMain = DEF_SUBMENU( optMainStr[0], optsMain );
+static struct SubMenu menuMain = DEF_SUBMENU( menuStr[0], optsMain );
 
 /* implementation */
 
@@ -388,9 +388,9 @@ static void optmenu_draw_opt(const struct Option *opt, s16 x, s16 y, u8 sel) {
                 // TODO: button names
                 if (opt->uval[i] == VK_INVALID) {
                     if (optmenu_binding && white)
-                        optmenu_draw_text(x, y-13, optBindStr[1], 1);
+                        optmenu_draw_text(x, y-13, bindStr[1], 1);
                     else
-                        optmenu_draw_text(x, y-13, optBindStr[0], white);
+                        optmenu_draw_text(x, y-13, bindStr[0], white);
                 } else {
                     uint_to_hex(opt->uval[i], buf);
                     optmenu_draw_text(x, y-13, buf, white);

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -1,7 +1,7 @@
 #ifdef EXT_OPTIONS_MENU
 
 #include "sm64.h"
-#include "include/text_strings.h"
+#include "text_strings.h"
 #include "engine/math_util.h"
 #include "audio/external.h"
 #include "game/camera.h"
@@ -35,7 +35,7 @@ static s32 l_counter = 0;
 
 // How to add stuff:
 // strings: add them to include/text_strings.h.in
-//          and to menuStr[] / opts*Str[]
+//          and to optMainStr[] / opts*Str[]
 // options: add them to the relevant options list
 // menus:   add a new submenu definition and a new
 //          option to the optsMain list
@@ -45,10 +45,14 @@ static const u8 toggleStr[][16] = {
     { TEXT_OPT_ENABLED },
 };
 
-static const u8 menuStr[][32] = {
-    { TEXT_OPT_HIGHLIGHT },
+static const u8 optSmallStr[][32] = {
     { TEXT_OPT_BUTTON1 },
     { TEXT_OPT_BUTTON2 },
+    { TEXT_OPT_L_HIGHLIGHT },
+    { TEXT_OPT_R_HIGHLIGHT },
+};
+
+static const u8 optMainStr[][32] = {
     { TEXT_OPT_OPTIONS },
     { TEXT_OPT_CAMERA },
     { TEXT_OPT_CONTROLS },
@@ -56,7 +60,6 @@ static const u8 menuStr[][32] = {
     { TEXT_OPT_AUDIO },
     { TEXT_EXIT_GAME },
     { TEXT_OPT_CHEATS },
-
 };
 
 static const u8 optsCameraStr[][32] = {
@@ -104,7 +107,7 @@ static const u8 optsCheatsStr[][64] = {
     { TEXT_OPT_CHEAT9 },
 };
 
-static const u8 bindStr[][32] = {
+static const u8 optBindStr[][32] = {
     { TEXT_OPT_UNBOUND },
     { TEXT_OPT_PRESSKEY },
     { TEXT_BIND_A },
@@ -122,7 +125,7 @@ static const u8 bindStr[][32] = {
     { TEXT_BIND_LEFT },
     { TEXT_BIND_RIGHT },
     { TEXT_OPT_DEADZONE },
-    { TEXT_OPT_RUMBLE }
+    { TEXT_OPT_RUMBLE },
 };
 
 static const u8 *filterChoices[] = {
@@ -233,24 +236,24 @@ static struct Option optsCamera[] = {
 #endif
 
 static struct Option optsControls[] = {
-    DEF_OPT_BIND( bindStr[ 2], configKeyA ),
-    DEF_OPT_BIND( bindStr[ 3], configKeyB ),
-    DEF_OPT_BIND( bindStr[ 4], configKeyStart ),
-    DEF_OPT_BIND( bindStr[ 5], configKeyL ),
-    DEF_OPT_BIND( bindStr[ 6], configKeyR ),
-    DEF_OPT_BIND( bindStr[ 7], configKeyZ ),
-    DEF_OPT_BIND( bindStr[ 8], configKeyCUp ),
-    DEF_OPT_BIND( bindStr[ 9], configKeyCDown ),
-    DEF_OPT_BIND( bindStr[10], configKeyCLeft ),
-    DEF_OPT_BIND( bindStr[11], configKeyCRight ),
-    DEF_OPT_BIND( bindStr[12], configKeyStickUp ),
-    DEF_OPT_BIND( bindStr[13], configKeyStickDown ),
-    DEF_OPT_BIND( bindStr[14], configKeyStickLeft ),
-    DEF_OPT_BIND( bindStr[15], configKeyStickRight ),
+    DEF_OPT_BIND( optBindStr[ 2], configKeyA ),
+    DEF_OPT_BIND( optBindStr[ 3], configKeyB ),
+    DEF_OPT_BIND( optBindStr[ 4], configKeyStart ),
+    DEF_OPT_BIND( optBindStr[ 5], configKeyL ),
+    DEF_OPT_BIND( optBindStr[ 6], configKeyR ),
+    DEF_OPT_BIND( optBindStr[ 7], configKeyZ ),
+    DEF_OPT_BIND( optBindStr[ 8], configKeyCUp ),
+    DEF_OPT_BIND( optBindStr[ 9], configKeyCDown ),
+    DEF_OPT_BIND( optBindStr[10], configKeyCLeft ),
+    DEF_OPT_BIND( optBindStr[11], configKeyCRight ),
+    DEF_OPT_BIND( optBindStr[12], configKeyStickUp ),
+    DEF_OPT_BIND( optBindStr[13], configKeyStickDown ),
+    DEF_OPT_BIND( optBindStr[14], configKeyStickLeft ),
+    DEF_OPT_BIND( optBindStr[15], configKeyStickRight ),
     // max deadzone is 31000; this is less than the max range of ~32768, but this
     // way, the player can't accidentally lock themselves out of using the stick
-    DEF_OPT_SCROLL( bindStr[16], &configStickDeadzone, 0, 100, 1 ),
-    DEF_OPT_SCROLL( bindStr[17], &configRumbleStrength, 0, 100, 1)
+    DEF_OPT_SCROLL( optBindStr[16], &configStickDeadzone, 0, 100, 1 ),
+    DEF_OPT_SCROLL( optBindStr[17], &configRumbleStrength, 0, 100, 1)
 };
 
 static struct Option optsVideo[] = {
@@ -285,33 +288,34 @@ static struct Option optsCheats[] = {
 /* submenu definitions */
 
 #ifdef BETTERCAMERA
-static struct SubMenu menuCamera   = DEF_SUBMENU( menuStr[4], optsCamera );
+static struct SubMenu menuCamera   = DEF_SUBMENU( optMainStr[1], optsCamera );
 #endif
-static struct SubMenu menuControls = DEF_SUBMENU( menuStr[5], optsControls );
-static struct SubMenu menuVideo    = DEF_SUBMENU( menuStr[6], optsVideo );
-static struct SubMenu menuAudio    = DEF_SUBMENU( menuStr[7], optsAudio );
-static struct SubMenu menuCheats   = DEF_SUBMENU( menuStr[9], optsCheats );
+static struct SubMenu menuControls = DEF_SUBMENU( optMainStr[2], optsControls );
+static struct SubMenu menuVideo    = DEF_SUBMENU( optMainStr[3], optsVideo );
+static struct SubMenu menuAudio    = DEF_SUBMENU( optMainStr[4], optsAudio );
+static struct SubMenu menuCheats   = DEF_SUBMENU( optMainStr[6], optsCheats );
 
 /* main options menu definition */
 
 static struct Option optsMain[] = {
 #ifdef BETTERCAMERA
-    DEF_OPT_SUBMENU( menuStr[4], &menuCamera ),
+    DEF_OPT_SUBMENU( optMainStr[1], &menuCamera ),
 #endif
-    DEF_OPT_SUBMENU( menuStr[5], &menuControls ),
-    DEF_OPT_SUBMENU( menuStr[6], &menuVideo ),
-    DEF_OPT_SUBMENU( menuStr[7], &menuAudio ),
-    DEF_OPT_BUTTON ( menuStr[8], optmenu_act_exit ),
+    DEF_OPT_SUBMENU( optMainStr[2], &menuControls ),
+    DEF_OPT_SUBMENU( optMainStr[3], &menuVideo ),
+    DEF_OPT_SUBMENU( optMainStr[4], &menuAudio ),
+    DEF_OPT_BUTTON ( optMainStr[5], optmenu_act_exit ),
     // NOTE: always keep cheats the last option here because of the half-assed way I toggle them
-    DEF_OPT_SUBMENU( menuStr[9], &menuCheats )
+    DEF_OPT_SUBMENU( optMainStr[6], &menuCheats )
 };
 
-static struct SubMenu menuMain = DEF_SUBMENU( menuStr[3], optsMain );
+static struct SubMenu menuMain = DEF_SUBMENU( optMainStr[0], optsMain );
 
 /* implementation */
 
 static s32 optmenu_option_timer = 0;
 static u8 optmenu_hold_count = 0;
+static s32 optmenu_sin_timer = 0;
 
 static struct SubMenu *currentMenu = &menuMain;
 
@@ -384,9 +388,9 @@ static void optmenu_draw_opt(const struct Option *opt, s16 x, s16 y, u8 sel) {
                 // TODO: button names
                 if (opt->uval[i] == VK_INVALID) {
                     if (optmenu_binding && white)
-                        optmenu_draw_text(x, y-13, bindStr[1], 1);
+                        optmenu_draw_text(x, y-13, optBindStr[1], 1);
                     else
-                        optmenu_draw_text(x, y-13, bindStr[0], white);
+                        optmenu_draw_text(x, y-13, optBindStr[0], white);
                 } else {
                     uint_to_hex(opt->uval[i], buf);
                     optmenu_draw_text(x, y-13, buf, white);
@@ -450,6 +454,7 @@ static inline s16 get_hudstr_centered_x(const s16 sx, const u8 *str) {
 void optmenu_draw(void) {
     s16 scroll;
     s16 scrollpos;
+    f32 sinpos;
 
     const s16 labelX = get_hudstr_centered_x(160, currentMenu->label);
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
@@ -465,6 +470,7 @@ void optmenu_draw(void) {
 
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
     gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 80, SCREEN_WIDTH, SCREEN_HEIGHT);
+    
     for (u8 i = 0; i < currentMenu->numOpts; i++) {
         scroll = 140 - 32 * i + currentMenu->scroll * 32;
         // FIXME: just start from the first visible option bruh
@@ -472,19 +478,18 @@ void optmenu_draw(void) {
             optmenu_draw_opt(&currentMenu->opts[i], 160, scroll, (currentMenu->select == i));
     }
 
+    sinpos = sins(optmenu_sin_timer*5000)*4;
     gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-    gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, 255);
-    gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
-    print_hud_lut_string(HUD_LUT_GLOBAL, 80, 90 + (32 * (currentMenu->select - currentMenu->scroll)), menuStr[0]);
-    print_hud_lut_string(HUD_LUT_GLOBAL, 224, 90 + (32 * (currentMenu->select - currentMenu->scroll)), menuStr[0]);
-    gSPDisplayList(gDisplayListHead++, dl_rgba16_text_end);
+    print_generic_string(80 - sinpos, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[2]);
+    print_generic_string(224 + sinpos, 132 - (32 * (currentMenu->select - currentMenu->scroll)), optSmallStr[3]);
+    gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
 }
 
 //This has been separated for interesting reasons. Don't question it.
 void optmenu_draw_prompt(void) {
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
-    optmenu_draw_text(264, 212, menuStr[1 + optmenu_open], 0);
+    optmenu_draw_text(264, 212, optSmallStr[optmenu_open], 0);
     gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
 }
 
@@ -506,7 +511,6 @@ void optmenu_toggle(void) {
 
         currentMenu = &menuMain;
         optmenu_open = 1;
-        
         /* Resets l_counter to 0 every time the options menu is open */
         l_counter = 0;
     } else {
@@ -539,6 +543,8 @@ void optmenu_check_buttons(void) {
     if (gPlayer1Controller->buttonPressed & R_TRIG)
         optmenu_toggle();
     
+    optmenu_sin_timer++;
+
     /* Enables cheats if the user press the L trigger 3 times while in the options menu. Also plays a sound. */
     
     if ((gPlayer1Controller->buttonPressed & L_TRIG) && !Cheats.EnableCheats) {


### PR DESCRIPTION
- Separate small strings from `menuStr` to `optSmallStr`

- Replace "O" option selection with moving arrows
