### PR TITLE
Added Build Flag "NO_BASE_GFX"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ EXT_OPTIONS_MENU ?= 1
 TEXTSAVES ?= 0
 # Load resources from external files
 EXTERNAL_DATA ?= 0
+# Only add sounds to base.zip
+NO_BASE_GFX ?= 0
 # Enable Discord Rich Presence
 DISCORDRPC ?= 0
 
@@ -702,10 +704,12 @@ $(BASEPACK_LST): $(EXE)
 	@echo "$(BUILD_DIR)/sound/sequences.bin sound/sequences.bin" >> $(BASEPACK_LST)
 	@echo "$(BUILD_DIR)/sound/sound_data.ctl sound/sound_data.ctl" >> $(BASEPACK_LST)
 	@echo "$(BUILD_DIR)/sound/sound_data.tbl sound/sound_data.tbl" >> $(BASEPACK_LST)
+ifeq ($(NO_BASE_GFX),0)
 	@$(foreach f, $(wildcard $(SKYTILE_DIR)/*), echo $(f) gfx/$(f:$(BUILD_DIR)/%=%) >> $(BASEPACK_LST);)
 	@find actors -name \*.png -exec echo "{} gfx/{}" >> $(BASEPACK_LST) \;
 	@find levels -name \*.png -exec echo "{} gfx/{}" >> $(BASEPACK_LST) \;
 	@find textures -name \*.png -exec echo "{} gfx/{}" >> $(BASEPACK_LST) \;
+endif
 
 # prepares the resource ZIP with base data
 $(BASEPACK_PATH): $(BASEPACK_LST)


### PR DESCRIPTION
with `NO_BASE_GFX=1` only the sound folder will be added to the base.zip when using `EXTERNAL_DATA=1`