### PR TITLE
Prevent crash in vanish cap switch course

### DIFF
--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -925,7 +925,7 @@ void find_surface_on_ray(Vec3f orig, Vec3f dir, struct Surface **hit_surface, Ve
 	}
 
     // increase collision checking precision (normally 1)
-    f32 precision = 3;
+    f32 precision = gCheckingSurfaceCollisionsForCamera ? 3 : 1;
 
     // Get cells we cross using DDA
     if (absx(dir[0]) >= absx(dir[2]))

--- a/src/game/behaviors/checkerboard_platform.inc.c
+++ b/src/game/behaviors/checkerboard_platform.inc.c
@@ -4,6 +4,14 @@ struct Struct8032F754 D_8032F754[] = { { 145, { 0.7f, 1.5f, 0.7f }, 7.0f },
                                        { 235, { 1.2f, 2.0f, 1.2f }, 11.6f } };
 
 void bhv_checkerboard_elevator_group_init(void) {
+    // Added to prevent a crash in the vanish cap stage
+    cur_obj_hide();
+    // Here's the theory: Since it is only valid for a few frames, I believe
+    // the model gets deallocated after removal. Since changing the camera
+    // precision makes the camera end up in a slightly different spot, it
+    // could be trying to render the object when `precision` is set to 3 but
+    // not to 1.
+
     s32 sp3C;
     s32 sp38;
     s32 sp34;


### PR DESCRIPTION
The segfault is hit while trying to render bhvCheckerboardElevatorGroup
when the player first enters the stage.

So here's some background: bhvCheckerboardElevatorGroup is the invisible
parent object that defines where the two platforms will rotate around. It
has a model, but it's never rendered in game. The entity only exists for
a few frames before being removed from the scene.

Here's the theory: Since it is only valid for a few frames, I believe the
model gets deallocated after removal. Since changing the camera precision
makes the camera end up in a slightly different spot, it could be trying
to render the object when precision is set to 3 but not to 1.

Here's the solution: Adding cur_obj_hide() to the start of
bhv_checkerboard_elevator_group_init() prevents the crash

fixes #437