### PR TITLE
powerpc leopard support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,7 +574,6 @@ ifeq ($(WINDOW_API),DXGI)
   endif
   BACKEND_LDFLAGS += -ld3dcompiler -ldxgi -ldxguid
   BACKEND_LDFLAGS += -lsetupapi -ldinput8 -luser32 -lgdi32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion -luuid -static
-# This isn't actually searched for includes on Leopard, and sdl-config is one directory too deep
 else ifeq ($(WINDOW_API),SDL2)
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += -lglew32 -lglu32 -lopengl32
@@ -598,7 +597,11 @@ endif
 
 # SDL can be used by different systems, so we consolidate all of that shit into this
 ifeq ($(SDL_USED),2)
+  ifeq ($(PPC_OSX_BUILD),1)
   BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags` -I/usr/local/include
+  else
+  BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags`
+  endif
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += `$(SDLCONFIG) --static-libs` -lsetupapi -luser32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion
   else
@@ -705,7 +708,7 @@ else ifeq ($(TARGET_RPI),1)
 
 else ifeq ($(OSX_BUILD),1)
   LDFLAGS := -lm $(BACKEND_LDFLAGS) -no-pie -lpthread
-# Flag -no-pie not available in MacPorts GCC 4.9
+# Flag -no-pie not available in MacPorts GCC 4.9, and most likely is not neccesary anyways according to https://opensource.apple.com/source/ld64/ld64-134.9/ld64-134.9/doc/man/man1/ld.1.auto.html
 else ifeq ($(PPC_OSX_BUILD),1)
   LDFLAGS := -lm $(BACKEND_LDFLAGS) -lpthread
 else

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ TARGET_WEB ?= 0
 # Makeflag to enable OSX fixes
 OSX_BUILD ?= 0
 
+# Makeflag to enable PowerPC OSX fixes
+PPC_OSX_BUILD ?= 0
+
 # Specify the target you are building for, TARGET_BITS=0 means native
 TARGET_ARCH ?= native
 TARGET_BITS ?= 0
@@ -203,7 +206,7 @@ ifeq ($(TARGET_RPI),1) # Define RPi to change SDL2 title & GLES2 hints
       VERSION_CFLAGS += -DUSE_GLES
 endif
 
-ifeq ($(OSX_BUILD),1) # Modify GFX & SDL2 for OSX GL
+ifeq (,$(filter 1,$(OSX_BUILD)$(PPC_OSX_BUILD))) # Modify GFX & SDL2 for OSX GL
      VERSION_CFLAGS += -DOSX_BUILD
 endif
 
@@ -223,6 +226,11 @@ ifneq (,$(filter $(RENDER_API),D3D11 D3D12))
   ifneq ($(WINDOW_API),DXGI)
     $(warning DirectX renderers require DXGI, forcing WINDOW_API value)
     WINDOW_API := DXGI
+  endif
+else ifeq ($(PPC_OSX_BUILD),1)
+	ifneq ($(RENDER_API),GL_LEGACY)
+    $(warning PowerPC OS X should use the GL_LEGACY RENDER_API, forcing GL_LEGACY value)
+	RENDER_API := GL_LEGACY
   endif
 else
   ifeq ($(WINDOW_API),DXGI)
@@ -496,7 +504,7 @@ ENDIAN_BITWIDTH := $(BUILD_DIR)/endian-and-bitwidth
 
 AS := $(CROSS)as
 
-ifeq ($(OSX_BUILD),1)
+ifeq (,$(filter 1,$(OSX_BUILD)$(PPC_OSX_BUILD)))
 AS := i686-w64-mingw32-as
 endif
 
@@ -530,6 +538,10 @@ else ifeq ($(OSX_BUILD),1)
   CPP := cpp-9 -P
   OBJDUMP := i686-w64-mingw32-objdump
   OBJCOPY := i686-w64-mingw32-objcopy
+else ifeq ($(PPC_OSX_BUILD),1)
+  CPP := cpp -P
+  OBJDUMP := i686-w64-mingw32-objdump
+  OBJCOPY := i686-w64-mingw32-objcopy
 else # Linux & other builds
   CPP := $(CROSS)cpp -P
   OBJCOPY := $(CROSS)objcopy
@@ -546,6 +558,10 @@ BACKEND_CFLAGS := -DRAPI_$(RENDER_API)=1 -DWAPI_$(WINDOW_API)=1 -DAAPI_$(AUDIO_A
 BACKEND_CFLAGS += $(foreach capi,$(CONTROLLER_API),-DCAPI_$(capi)=1)
 BACKEND_LDFLAGS :=
 SDL2_USED := 0
+# GCC 4.9 needs this set explicitly
+ifeq ($(PPC_OSX_BUILD),1)
+  BACKEND_CFLAGS += -std=c11
+endif
 
 # for now, it's either SDL+GL or DXGI+DirectX, so choose based on WAPI
 ifeq ($(WINDOW_API),DXGI)
@@ -558,12 +574,13 @@ ifeq ($(WINDOW_API),DXGI)
   endif
   BACKEND_LDFLAGS += -ld3dcompiler -ldxgi -ldxguid
   BACKEND_LDFLAGS += -lsetupapi -ldinput8 -luser32 -lgdi32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion -luuid -static
+# This isn't actually searched for includes on Leopard, and sdl-config is one directory too deep
 else ifeq ($(WINDOW_API),SDL2)
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += -lglew32 -lglu32 -lopengl32
   else ifeq ($(TARGET_RPI),1)
     BACKEND_LDFLAGS += -lGLESv2
-  else ifeq ($(OSX_BUILD),1)
+  else ifeq (,$(filter 1,$(OSX_BUILD)$(PPC_OSX_BUILD)))
     BACKEND_LDFLAGS += -framework OpenGL `pkg-config --libs glew`
   else
     BACKEND_LDFLAGS += -lGL
@@ -581,7 +598,7 @@ endif
 
 # SDL can be used by different systems, so we consolidate all of that shit into this
 ifeq ($(SDL_USED),2)
-  BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags`
+  BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags` -I/usr/local/include
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += `$(SDLCONFIG) --static-libs` -lsetupapi -luser32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion
   else
@@ -688,7 +705,9 @@ else ifeq ($(TARGET_RPI),1)
 
 else ifeq ($(OSX_BUILD),1)
   LDFLAGS := -lm $(BACKEND_LDFLAGS) -no-pie -lpthread
-
+# Flag -no-pie not available in MacPorts GCC 4.9
+else ifeq ($(PPC_OSX_BUILD),1)
+  LDFLAGS := -lm $(BACKEND_LDFLAGS) -lpthread
 else
   LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -no-pie -lpthread
   ifeq ($(DISCORDRPC),1)

--- a/Makefile
+++ b/Makefile
@@ -597,11 +597,7 @@ endif
 
 # SDL can be used by different systems, so we consolidate all of that shit into this
 ifeq ($(SDL_USED),2)
-  ifeq ($(PPC_OSX_BUILD),1)
-  BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags` -I/usr/local/include
-  else
   BACKEND_CFLAGS += -DHAVE_SDL2=1 `$(SDLCONFIG) --cflags`
-  endif
   ifeq ($(WINDOWS_BUILD),1)
     BACKEND_LDFLAGS += `$(SDLCONFIG) --static-libs` -lsetupapi -luser32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion
   else

--- a/README_es_ES.md
+++ b/README_es_ES.md
@@ -155,6 +155,11 @@ sudo xbps-install -S base-devel python3 audiofile-devel SDL2-devel glew-devel
 sudo xbps-install -S base-devel python3 audiofile-devel-32bit SDL2-devel-32bit glew-devel-32bit
 ```
 
+##### Alpine Linux - (compilando para 32 bits y 64 bits)
+```
+sudo apk add build-base python3 audiofile-dev sdl2-dev glew-dev
+```
+
 #### Compila el ejecutable.
 
 Ejecuta `make` para compilar (por defecto `VERSION=us`)

--- a/src/pc/audio/audio_sdl.c
+++ b/src/pc/audio/audio_sdl.c
@@ -1,6 +1,9 @@
 #ifdef AAPI_SDL2
-
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <SDL2/SDL.h>
+#else
+#include <SDL.h>
+#endif
 
 #include "audio_api.h"
 

--- a/src/pc/audio/audio_sdl.c
+++ b/src/pc/audio/audio_sdl.c
@@ -17,7 +17,7 @@ static bool audio_sdl_init(void) {
     SDL_AudioSpec want, have;
     SDL_zero(want);
     want.freq = 32000;
-    want.format = AUDIO_S16;
+    want.format = AUDIO_S16SYS;
     want.channels = 2;
     want.samples = 512;
     want.callback = NULL;

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -2,7 +2,10 @@
 
 #include <stdio.h>
 #include <stdint.h>
+// stdbool.h can not be defined (and does not need to be defined) on the below platform
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__) && !defined(__GNU__C)
 #include <stdbool.h>
+#endif
 #include <math.h>
 
 #include <SDL2/SDL.h>

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -3,12 +3,15 @@
 #include <stdio.h>
 #include <stdint.h>
 // stdbool.h can not be defined (and does not need to be defined) on the below platform
-#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__) && !defined(__GNU__C)
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <stdbool.h>
 #endif
 #include <math.h>
-
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <SDL2/SDL.h>
+#else
+#include <SDL.h>
+#endif
 
 // Analog camera movement by Pathétique (github.com/vrmiguel), y0shin and Mors
 // Contribute or communicate bugs at github.com/vrmiguel/sm64-analog-camera

--- a/src/pc/discord/discordrpc.c
+++ b/src/pc/discord/discordrpc.c
@@ -186,7 +186,7 @@ static void set_state(void) {
         // when exiting a stage the act doesn't get reset
         if (gCurrActNum && gCurrCourseNum) {
             // any stage over 19 is a special stage without acts
-            if (gCurrCourseNum <= COURSE_STAGES_MAX) {
+            if (gCurrCourseNum < 19) {
                 void **actNameTbl;
 #ifndef VERSION_EU
                 actNameTbl = segmented_to_virtual(seg2_act_name_table);

--- a/src/pc/discord/discordrpc.c
+++ b/src/pc/discord/discordrpc.c
@@ -186,7 +186,7 @@ static void set_state(void) {
         // when exiting a stage the act doesn't get reset
         if (gCurrActNum && gCurrCourseNum) {
             // any stage over 19 is a special stage without acts
-            if (gCurrCourseNum < 19) {
+            if (gCurrCourseNum <= COURSE_STAGES_MAX) {
                 void **actNameTbl;
 #ifndef VERSION_EU
                 actNameTbl = segmented_to_virtual(seg2_act_name_table);

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 // stdbool.h can not be defined (and does not need to be defined) on the below platform
-#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__) && !defined(__GNU__C)
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <stdbool.h>	#include <stdbool.h>
 #endif
 
@@ -22,13 +22,25 @@
 # include <GL/glew.h>
 #endif
 
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <SDL2/SDL.h>
+#else
+#include <SDL.h>
+#endif
 
 #define GL_GLEXT_PROTOTYPES 1
 #ifdef USE_GLES
-# include <SDL2/SDL_opengles2.h>
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
+#include <SDL2/SDL_opengles2.h>
 #else
-# include <SDL2/SDL_opengl.h>
+#include <SDL_opengles2.h>
+#endif
+#else
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
+#include <SDL2/SDL_opengl.h>
+#else
+#include <SDL_opengl.h>
+#endif
 #endif
 
 #include "../platform.h"

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -1,7 +1,10 @@
 #ifdef RAPI_GL
 
 #include <stdint.h>
-#include <stdbool.h>
+// stdbool.h can not be defined (and does not need to be defined) on the below platform
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__) && !defined(__GNU__C)
+#include <stdbool.h>	#include <stdbool.h>
+#endif
 
 #ifndef _LANGUAGE_C
 # define _LANGUAGE_C

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 // stdbool.h can not be defined (and does not need to be defined) on the below platform
 #if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
-#include <stdbool.h>	#include <stdbool.h>
+#include <stdbool.h>
 #endif
 
 #ifndef _LANGUAGE_C

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -1,7 +1,10 @@
 #ifdef RAPI_GL_LEGACY
 
 #include <stdint.h>
+// stdbool.h can not be defined (and does not need to be defined) on the below platform
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__) && !defined(__GNU__C)
 #include <stdbool.h>
+#endif
 #include <assert.h>
 
 #ifndef _LANGUAGE_C

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 // stdbool.h can not be defined (and does not need to be defined) on the below platform
-#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__) && !defined(__GNU__C)
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <stdbool.h>
 #endif
 #include <assert.h>
@@ -18,15 +18,18 @@
 # define FOR_WINDOWS 0
 #endif
 
-#include <SDL2/SDL.h>
-
 #if FOR_WINDOWS || defined(OSX_BUILD)
 # define GLEW_STATIC
 # include <GL/glew.h>
 #endif
 
 #define GL_GLEXT_PROTOTYPES 1
-#include <SDL2/SDL_opengl.h>
+
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
+#include <SDL2/SDL.h>
+#else
+#include <SDL.h>
+#endif
 
 // redefine this if using a different GL loader
 #define mglGetProcAddress(name) SDL_GL_GetProcAddress(name)

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -13,11 +13,19 @@
 #define GL_GLEXT_PROTOTYPES 1
 #include <SDL2/SDL_opengl.h>
 #else
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <SDL2/SDL.h>
+#else
+#include <SDL.h>
+#endif
 #define GL_GLEXT_PROTOTYPES 1
 
 #ifdef OSX_BUILD
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <SDL2/SDL_opengl.h>
+#else
+#include <SDL_opengl.h>
+#endif
 #else
 #include <SDL2/SDL_opengles2.h>
 #endif

--- a/src/pc/platform.c
+++ b/src/pc/platform.c
@@ -82,7 +82,11 @@ void sys_fatal(const char *fmt, ...) {
 #ifdef HAVE_SDL2
 
 // we can just ask SDL for most of this shit if we have it
+#if !defined(__APPLE__) && !defined(__BIG_ENDIAN__)
 #include <SDL2/SDL.h>
+#else
+#include <SDL.h>
+#endif
 
 const char *sys_user_path(void) {
     static char path[SYS_MAX_PATH] = { 0 };

--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -620,6 +620,8 @@ extern "C" {
 #define __attribute__(x)
 #endif
 
+extern long long int llrint ( double x );
+
 void _af_error (int errorCode, const char *fmt, ...)
 	__attribute__((format(printf, 2, 3)));
 
@@ -5075,7 +5077,7 @@ bool ModuleState::fileModuleHandlesSeeking() const
 
 status ModuleState::setup(AFfilehandle file, Track *track)
 {
-	AFframecount fframepos = std::llrint(track->nextvframe * track->f.sampleRate / track->v.sampleRate);
+	AFframecount fframepos = llrint(track->nextvframe * track->f.sampleRate / track->v.sampleRate);
 	bool isReading = file->m_access == _AF_READ_ACCESS;
 
 	if (!track->v.isUncompressed())
@@ -5146,11 +5148,11 @@ status ModuleState::setup(AFfilehandle file, Track *track)
 		if (track->totalfframes == -1)
 			track->totalvframes = -1;
 		else
-			track->totalvframes = std::llrint(track->totalfframes *
+			track->totalvframes = llrint(track->totalfframes *
 				(track->v.sampleRate / track->f.sampleRate));
 
 		track->nextfframe = fframepos;
-		track->nextvframe = std::llrint(fframepos * track->v.sampleRate / track->f.sampleRate);
+		track->nextvframe = llrint(fframepos * track->v.sampleRate / track->f.sampleRate);
 
 		m_isDirty = false;
 

--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -620,7 +620,10 @@ extern "C" {
 #define __attribute__(x)
 #endif
 
+// This function can not be found by MacPorts GCC 4.9 and needs to be explicitly stated
+#if defined(__APPLE__) && defined(__BIG_ENDIAN__) && defined(__GNU__C)
 extern long long int llrint ( double x );
+#endif
 
 void _af_error (int errorCode, const char *fmt, ...)
 	__attribute__((format(printf, 2, 3)));

--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -621,7 +621,7 @@ extern "C" {
 #endif
 
 // This function can not be found by MacPorts GCC 4.9 and needs to be explicitly stated
-#if defined(__APPLE__) && defined(__BIG_ENDIAN__) && defined(__GNU__C)
+#if defined(__APPLE__) && defined(__BIG_ENDIAN__)
 extern long long int llrint ( double x );
 #endif
 


### PR DESCRIPTION
This adds the target 'PPC_OSX_BUILD' and makes some slight modifications to allow the MacPorts GCC 4.9 compiler to compile this project. However, you will need to use this modified SDL2 2.0.6 to link against:

https://github.com/alex-free/tiger_sdl2.0.6

The above SDL should be compiled with an original Apple compiler:

sudo port select --set gcc gcc40

SM64ex should be compiled with the MacPorts GCC 4.9:

sudo port select --set gcc mp-gcc49

Besides that, using MacPorts to get all the normal Mac OS X dependencies is all that's required + python3.9 and gmake. GCC 4.9 can take days to compile, to jump start the proccess you can use my binary installer at:

https://macintoshgarden.org/apps/gcc-mp-49

Everything is working well, except sound is a bit distorted. It gets more distorted when more samples/audio are played at once, I can't figure this out yet, any help would be appreciated.