### PR TITLE
mac os x powerpc support + fix mac sdl1 (supersedes #443)

### DIFF
--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -266,7 +266,11 @@ void main_func(void) {
 #endif
 }
 
+#if defined(WAPI_SDL1) && defined(__APPLE__)
+int SDL_main(int argc, char *argv[]) {
+#else
 int main(int argc, char *argv[]) {
+#endif
     parse_cli_opts(argc, argv);
     main_func();
     return 0;


### PR DESCRIPTION
Sorry for opening another pull request, but I thought it would be easier to just redo the patches against nightly in the nightly branch of my fork.
 
I've disabled the function that copies saves from the old location to the new location for PPC Mac OS X only, as it won't compile as is.

The GL_LEGACY and SDL2 options have been tested to work. Will try SDL1 next.