### PR TITLE
Makefile: more robust macOS build support + improvements to build speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ DEP_FILES := $(O_FILES:.o=.d) $(ULTRA_O_FILES:.o=.d) $(GODDARD_O_FILES:.o=.d) $(
 SEG_FILES := $(SEGMENT_ELF_FILES) $(ACTOR_ELF_FILES) $(LEVEL_ELF_FILES)
 
 ##################### Compiler Options #######################
-INCLUDE_CFLAGS := $(PLATFORM_CFLAGS) -I include -I $(BUILD_DIR) -I $(BUILD_DIR)/include -I src -I .
+INCLUDE_CFLAGS := -I include -I $(BUILD_DIR) -I $(BUILD_DIR)/include -I src -I .
 ENDIAN_BITWIDTH := $(BUILD_DIR)/endian-and-bitwidth
 
 # Huge deleted N64 section was here
@@ -573,9 +573,8 @@ else ifeq ($(TARGET_WEB),1)
 
 # Linux / Other builds below
 else
-  CC_CHECK := $(CC) -fsyntax-only -fsigned-char $(BACKEND_CFLAGS) $(INCLUDE_CFLAGS) -Wall -Wextra -Wno-format-security $(VERSION_CFLAGS) $(GRUCODE_CFLAGS)
-  CFLAGS := $(OPT_FLAGS) $(INCLUDE_CFLAGS) $(BACKEND_CFLAGS) $(VERSION_CFLAGS) $(GRUCODE_CFLAGS) -fno-strict-aliasing -fwrapv
-
+  CC_CHECK := $(CC) -fsyntax-only -fsigned-char $(BACKEND_CFLAGS) $(PLATFORM_CFLAGS) $(INCLUDE_CFLAGS) -Wall -Wextra -Wno-format-security $(VERSION_CFLAGS) $(GRUCODE_CFLAGS)
+  CFLAGS := $(OPT_FLAGS) $(PLATFORM_CFLAGS) $(INCLUDE_CFLAGS) $(BACKEND_CFLAGS) $(VERSION_CFLAGS) $(GRUCODE_CFLAGS) -fno-strict-aliasing -fwrapv
 endif
 
 # Check for enhancement options

--- a/Makefile
+++ b/Makefile
@@ -166,9 +166,8 @@ VERSION_ASFLAGS := --defsym $(VERSION_DEF)=1
 # Stuff for showing the git hash in the intro on nightly builds
 # From https://stackoverflow.com/questions/44038428/include-git-commit-hash-and-or-branch-name-in-c-c-source
 ifeq ($(shell git rev-parse --abbrev-ref HEAD),nightly)
-  GIT_HASH=`git rev-parse --short HEAD`
-  COMPILE_TIME=`date -u +'%Y-%m-%d %H:%M:%S UTC'`
-  VERSION_CFLAGS += -DNIGHTLY -DGIT_HASH="\"$(GIT_HASH)\"" -DCOMPILE_TIME="\"$(COMPILE_TIME)\""
+  GIT_HASH := $(shell git rev-parse --short HEAD)
+  VERSION_CFLAGS += -DNIGHTLY -DGIT_HASH="\"$(GIT_HASH)\""
 endif
 
 # Microcode
@@ -528,7 +527,7 @@ else ifeq ($(findstring SDL,$(WINDOW_API)),SDL)
   else ifeq ($(TARGET_RPI),1)
     BACKEND_LDFLAGS += -lGLESv2
   else ifeq ($(OSX_BUILD),1)
-    BACKEND_LDFLAGS += -framework OpenGL `pkg-config --libs glew`
+    BACKEND_LDFLAGS += -framework OpenGL $(shell pkg-config --libs glew)
   else
     BACKEND_LDFLAGS += -lGL
   endif
@@ -557,11 +556,11 @@ else ifeq ($(SDL1_USED),1)
 endif
 
 ifneq ($(SDL1_USED)$(SDL2_USED),00)
-  BACKEND_CFLAGS += `$(SDLCONFIG) --cflags`
+  BACKEND_CFLAGS += $(shell $(SDLCONFIG) --cflags)
   ifeq ($(WINDOWS_BUILD),1)
-    BACKEND_LDFLAGS += `$(SDLCONFIG) --static-libs` -lsetupapi -luser32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion
+    BACKEND_LDFLAGS += $(shell $(SDLCONFIG) --static-libs) -lsetupapi -luser32 -limm32 -lole32 -loleaut32 -lshell32 -lwinmm -lversion
   else
-    BACKEND_LDFLAGS += `$(SDLCONFIG) --libs`
+    BACKEND_LDFLAGS += $(shell $(SDLCONFIG) --libs)
   endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -452,8 +452,7 @@ DEP_FILES := $(O_FILES:.o=.d) $(ULTRA_O_FILES:.o=.d) $(GODDARD_O_FILES:.o=.d) $(
 # Segment elf files
 SEG_FILES := $(SEGMENT_ELF_FILES) $(ACTOR_ELF_FILES) $(LEVEL_ELF_FILES)
 
-############################ Compiler Options ##################################
-
+##################### Compiler Options #######################
 INCLUDE_CFLAGS := $(PLATFORM_CFLAGS) -I include -I $(BUILD_DIR) -I $(BUILD_DIR)/include -I src -I .
 ENDIAN_BITWIDTH := $(BUILD_DIR)/endian-and-bitwidth
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,5 @@
-CC := gcc
-CXX := g++
+CC ?= gcc
+CXX ?= g++
 CFLAGS := -I../include -I. -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -O2 -s
 LDFLAGS := -lm
 PROGRAMS := n64graphics n64graphics_ci mio0 n64cksum textconv patch_libultra_math aifc_decode aiff_extract_codebook vadpcm_enc tabledesign extract_data_for_mio skyconv
@@ -38,7 +38,7 @@ skyconv_SOURCES := skyconv.c n64graphics.c utils.c
 LIBAUDIOFILE := audiofile/libaudiofile.a
 
 $(LIBAUDIOFILE):
-	@$(MAKE) -C audiofile
+	@CC=$(CC) CXX=$(CXX) $(MAKE) -C audiofile
 
 all: $(LIBAUDIOFILE) $(PROGRAMS) $(CXX_PROGRAMS)
 

--- a/tools/audiofile/Makefile
+++ b/tools/audiofile/Makefile
@@ -1,4 +1,4 @@
-CXX := g++
+CXX ?= g++
 
 libaudiofile.a: audiofile.o
 	ar rcs libaudiofile.a audiofile.o


### PR DESCRIPTION
**macOS Build Support**
1. detects whether Homebrew or MacPorts is installed and throws a error hint if not
2. passes compilers along to sub-makes for building tools
3. replaces `echo -n` with `touch`
4. fixes cleantools target

**Build Speed Improvements**
1. uses a "simply expanded" (`:=`) style variable for `GIT_HASH` so it's pre-expanded
2. replaces backticks with make shell (`$(shell ...)`) so commands are pre-expanded
3. should show at least moderate improvements in build times by avoiding multiple shell calls per compiler call
(at the very least on I/O bound platforms like `MSYS2`)

[Tested on macOS 10.15 / Win10-x64 / Ubuntu-x64 19.10]