### PR TITLE
Added Draw Distance option to Display settings

### DIFF
--- a/include/text_options_strings.h.in
+++ b/include/text_options_strings.h.in
@@ -56,6 +56,7 @@
 #define TEXT_OPT_AUTO      _("AUTO")
 #define TEXT_OPT_HUD       _("HUD")
 #define TEXT_OPT_THREEPT   _("THREE POINT")
+#define TEXT_OPT_DRAWDIST  _("DRAW DISTANCE")
 #define TEXT_OPT_APPLY     _("APPLY")
 #define TEXT_OPT_RESETWND  _("RESET WINDOW")
 
@@ -120,6 +121,7 @@
 #define TEXT_OPT_AUTO      _("Auto")
 #define TEXT_OPT_HUD       _("HUD")
 #define TEXT_OPT_THREEPT   _("Three-point")
+#define TEXT_OPT_DRAWDIST  _("Draw Distance")
 #define TEXT_OPT_APPLY     _("Apply")
 #define TEXT_OPT_RESETWND  _("Reset Window")
 

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -13,6 +13,7 @@
 #include "game/object_list_processor.h"
 #include "graph_node.h"
 #include "surface_collision.h"
+#include "pc/configfile.h"
 
 // Macros for retrieving arguments from behavior scripts.
 #define BHV_CMD_GET_1ST_U8(index)  (u8)((gCurBhvCommand[index] >> 24) & 0xFF) // unused
@@ -999,7 +1000,7 @@ void cur_obj_update(void) {
         if (!(objFlags & OBJ_FLAG_ACTIVE_FROM_AFAR)) {
             // If the object has a render distance, check if it should be shown.
 #ifndef NODRAWINGDISTANCE
-            if (distanceFromMario > gCurrentObject->oDrawingDistance) {
+            if (distanceFromMario > gCurrentObject->oDrawingDistance * configDrawDistance / 100.0f) {
                 // Out of render distance, hide the object.
                 gCurrentObject->header.gfx.node.flags &= ~GRAPH_RENDER_ACTIVE;
                 gCurrentObject->activeFlags |= ACTIVE_FLAG_FAR_AWAY;

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -13,7 +13,9 @@
 #include "game/object_list_processor.h"
 #include "graph_node.h"
 #include "surface_collision.h"
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // Macros for retrieving arguments from behavior scripts.
 #define BHV_CMD_GET_1ST_U8(index)  (u8)((gCurBhvCommand[index] >> 24) & 0xFF) // unused

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -14,6 +14,7 @@
 #include "game/mario.h"
 #include "game/object_list_processor.h"
 #include "surface_load.h"
+#include "pc/configfile.h"
 
 s32 unused8038BE90;
 
@@ -786,7 +787,7 @@ void load_object_collision_model(void) {
     }
 
 #ifndef NODRAWINGDISTANCE
-    if (marioDist < gCurrentObject->oDrawingDistance) {
+    if (marioDist < gCurrentObject->oDrawingDistance * configDrawDistance / 100.0f) {
 #endif
         gCurrentObject->header.gfx.node.flags |= GRAPH_RENDER_ACTIVE;
 #ifndef NODRAWINGDISTANCE

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -14,7 +14,9 @@
 #include "game/mario.h"
 #include "game/object_list_processor.h"
 #include "surface_load.h"
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 s32 unused8038BE90;
 

--- a/src/game/behaviors/bub.inc.c
+++ b/src/game/behaviors/bub.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // bub.c.inc
 
 // NOTE: These first set of functions spawn a school of bub depending on objF4's
@@ -9,7 +11,7 @@ void bub_spawner_act_0(void) {
     s32 i;
     s32 sp18 = o->oBirdChirpChirpUnkF4;
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 1500.0f) {
+    if (o->oDistanceToMario < 15 * configDrawDistance) {
 #endif
         for (i = 0; i < sp18; i++)
             spawn_object(o, MODEL_BUB, bhvBub);

--- a/src/game/behaviors/bub.inc.c
+++ b/src/game/behaviors/bub.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // bub.c.inc
 

--- a/src/game/behaviors/chain_chomp.inc.c
+++ b/src/game/behaviors/chain_chomp.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/chain_chomp.inc.c
+++ b/src/game/behaviors/chain_chomp.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvChainChomp, bhvChainChompChainPart, bhvWoodenPost, and bhvChainChompGate.
@@ -54,7 +56,7 @@ static void chain_chomp_act_uninitialized(void) {
     s32 i;
 
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 3000.0f) {
+    if (o->oDistanceToMario < 30 * configDrawDistance) {
 #endif
         segments = mem_pool_alloc(gObjectMemoryPool, 5 * sizeof(struct ChainSegment));
         if (segments != NULL) {
@@ -364,7 +366,7 @@ static void chain_chomp_act_move(void) {
 
     // Unload chain if mario is far enough
 #ifndef NODRAWINGDISTANCE
-    if (o->oChainChompReleaseStatus == CHAIN_CHOMP_NOT_RELEASED && o->oDistanceToMario > 4000.0f) {
+    if (o->oChainChompReleaseStatus == CHAIN_CHOMP_NOT_RELEASED && o->oDistanceToMario > 40 * configDrawDistance) {
         o->oAction = CHAIN_CHOMP_ACT_UNLOAD_CHAIN;
         o->oForwardVel = o->oVelY = 0.0f;
     } else {

--- a/src/game/behaviors/cloud.inc.c
+++ b/src/game/behaviors/cloud.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvCloud and bhvCloudPart.
@@ -48,7 +50,7 @@ static void cloud_act_spawn_parts(void) {
  */
 static void cloud_act_fwoosh_hidden(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         cur_obj_unhide();
         o->oAction = CLOUD_ACT_SPAWN_PARTS;
@@ -63,7 +65,7 @@ static void cloud_act_fwoosh_hidden(void) {
  */
 static void cloud_fwoosh_update(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 2500.0f) {
+    if (o->oDistanceToMario > 25 * configDrawDistance) {
         o->oAction = CLOUD_ACT_UNLOAD;
     } else {
 #endif

--- a/src/game/behaviors/cloud.inc.c
+++ b/src/game/behaviors/cloud.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/coin.inc.c
+++ b/src/game/behaviors/coin.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // coin.c.inc
 

--- a/src/game/behaviors/coin.inc.c
+++ b/src/game/behaviors/coin.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // coin.c.inc
 
 struct ObjectHitbox sYellowCoinHitbox = {
@@ -185,7 +187,7 @@ void bhv_coin_formation_loop(void) {
     switch (o->oAction) {
         case 0:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario < 2000.0f) {
+            if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
                 for (bitIndex = 0; bitIndex < 8; bitIndex++) {
                     if (!(o->oCoinUnkF4 & (1 << bitIndex)))
@@ -198,7 +200,7 @@ void bhv_coin_formation_loop(void) {
             break;
         case 1:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario > 2100.0f)
+            if (o->oDistanceToMario > 21 * configDrawDistance)
                 o->oAction++;
 #endif
             break;

--- a/src/game/behaviors/enemy_lakitu.inc.c
+++ b/src/game/behaviors/enemy_lakitu.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/enemy_lakitu.inc.c
+++ b/src/game/behaviors/enemy_lakitu.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvEnemyLakitu.
@@ -25,7 +27,7 @@ static struct ObjectHitbox sEnemyLakituHitbox = {
  */
 static void enemy_lakitu_act_uninitialized(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         spawn_object_relative_with_scale(CLOUD_BP_LAKITU_CLOUD, 0, 0, 0, 2.0f, o, MODEL_MIST, bhvCloud);
 

--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 /**
  * @file fish.inc.c
@@ -21,22 +23,22 @@ void fish_act_spawn(void) {
         
         // Blue fish with a quanitiy of twenty.
         case 0:
-            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Blue fish with a quanitiy of five.
         case 1:
-            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Cyan fish with a quanitiy of twenty.
         case 2:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
             
         // Cyan fish with a quanitiy of five.
         case 3:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
     }
     /**
@@ -45,7 +47,7 @@ void fish_act_spawn(void) {
      * Fish moves at random with a max-range of 700.0f.
      */
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < minDistToMario || gCurrLevelNum == LEVEL_SA) {
+    if (o->oDistanceToMario < minDistToMario * configDrawDistance / 100 || gCurrLevelNum == LEVEL_SA) {
 #endif
         for (i = 0; i < schoolQuantity; i++) {
             fishObject = spawn_object(o, model, bhvFish);

--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -23,22 +23,22 @@ void fish_act_spawn(void) {
         
         // Blue fish with a quanitiy of twenty.
         case 0:
-            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Blue fish with a quanitiy of five.
         case 1:
-            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Cyan fish with a quanitiy of twenty.
         case 2:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
             
         // Cyan fish with a quanitiy of five.
         case 3:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
     }
     /**

--- a/src/game/behaviors/fish.inc.c
+++ b/src/game/behaviors/fish.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 /**
  * @file fish.inc.c
  * Implements behaviour and spawning for fish located in the Secret Aquarium and other levels.
@@ -19,22 +21,22 @@ void fish_act_spawn(void) {
         
         // Blue fish with a quanitiy of twenty.
         case 0:
-            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Blue fish with a quanitiy of five.
         case 1:
-            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
+            model = MODEL_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = blue_fish_seg3_anims_0301C2B0;
             break;
             
         // Cyan fish with a quanitiy of twenty.
         case 2:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 20;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
             
         // Cyan fish with a quanitiy of five.
         case 3:
-            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 1500.0f;    fishAnimation = cyan_fish_seg6_anims_0600E264;
+            model = MODEL_CYAN_FISH;    schoolQuantity = 5;    minDistToMario = 15 * configDrawDistance;    fishAnimation = cyan_fish_seg6_anims_0600E264;
             break;
     }
     /**
@@ -64,7 +66,7 @@ void fish_act_spawn(void) {
 void fish_act_respawn(void) {
 #ifndef NODRAWINGDISTANCE
     if (gCurrLevelNum != LEVEL_SA) {
-        if (gMarioObject->oPosY - o->oPosY > 2000.0f) {
+        if (gMarioObject->oPosY - o->oPosY > 20 * configDrawDistance) {
             o->oAction = FISH_ACT_RESPAWN;
         }
     }

--- a/src/game/behaviors/goomba.inc.c
+++ b/src/game/behaviors/goomba.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/goomba.inc.c
+++ b/src/game/behaviors/goomba.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvGoomba and bhvGoombaTripletSpawner,
@@ -79,7 +81,7 @@ void bhv_goomba_triplet_spawner_update(void) {
     // spawn them
     if (o->oAction == GOOMBA_TRIPLET_SPAWNER_ACT_UNLOADED) {
 #ifndef NODRAWINGDISTANCE
-        if (o->oDistanceToMario < 3000.0f) {
+        if (o->oDistanceToMario < 30 * configDrawDistance) {
 #endif
             // The spawner is capable of spawning more than 3 goombas, but this
             // is not used in the game
@@ -102,7 +104,7 @@ void bhv_goomba_triplet_spawner_update(void) {
             o->oAction += 1;
 #ifndef NODRAWINGDISTANCE
         }
-    } else if (o->oDistanceToMario > 4000.0f) {
+    } else if (o->oDistanceToMario > 40 * configDrawDistance) {
         // If mario is too far away, enter the unloaded action. The goombas
         // will detect this and unload themselves
         o->oAction = GOOMBA_TRIPLET_SPAWNER_ACT_UNLOADED;

--- a/src/game/behaviors/heave_ho.inc.c
+++ b/src/game/behaviors/heave_ho.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // heave_ho.c.inc
 
 s16 D_8032F460[][2] = { { 30, 0 }, { 42, 1 }, { 52, 0 },  { 64, 1 },  { 74, 0 },
@@ -73,7 +75,7 @@ void heave_ho_act_3(void) {
 
 void heave_ho_act_0(void) {
 #ifndef NODRAWINGDISTANCE
-    if (find_water_level(o->oPosX, o->oPosZ) < o->oPosY && o->oDistanceToMario < 4000.0f) {
+    if (find_water_level(o->oPosX, o->oPosZ) < o->oPosY && o->oDistanceToMario < 40 * configDrawDistance) {
 #else
     if (find_water_level(o->oPosX, o->oPosZ) < (o->oPosY - 50.0f)) {
 #endif

--- a/src/game/behaviors/heave_ho.inc.c
+++ b/src/game/behaviors/heave_ho.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // heave_ho.c.inc
 

--- a/src/game/behaviors/king_bobomb.inc.c
+++ b/src/game/behaviors/king_bobomb.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // king_bobomb.c.inc
 

--- a/src/game/behaviors/king_bobomb.inc.c
+++ b/src/game/behaviors/king_bobomb.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // king_bobomb.c.inc
 
 // Copy of geo_update_projectile_pos_from_parent
@@ -296,7 +298,7 @@ void king_bobomb_move(void) {
     cur_obj_call_action_function(sKingBobombActions);
     exec_anim_sound_state(sKingBobombSoundStates);
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 5000.0f)
+    if (o->oDistanceToMario < 50 * configDrawDistance)
 #endif
         cur_obj_enable_rendering();
 #ifndef NODRAWINGDISTANCE

--- a/src/game/behaviors/lll_floating_wood_piece.inc.c
+++ b/src/game/behaviors/lll_floating_wood_piece.inc.c
@@ -1,5 +1,7 @@
 // lll_floating_wood_piece.c.inc
 
+#include "pc/configfile.h"
+
 void bhv_lll_wood_piece_loop(void) {
     if (o->oTimer == 0)
         o->oPosY -= 100.0f;
@@ -15,7 +17,7 @@ void bhv_lll_floating_wood_bridge_loop(void) {
     switch (o->oAction) {
         case 0:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario < 2500.0f) {
+            if (o->oDistanceToMario < 25 * configDrawDistance) {
 #endif
                 for (i = 1; i < 4; i++) {
                     sp3C = spawn_object_relative(0, (i - 2) * 300, 0, 0, o, MODEL_LLL_WOOD_BRIDGE,
@@ -29,7 +31,7 @@ void bhv_lll_floating_wood_bridge_loop(void) {
             break;
         case 1:
 #ifndef NODRAWINGDISTANCE
-            if (o->oDistanceToMario > 2600.0f)
+            if (o->oDistanceToMario > 26 * configDrawDistance)
                 o->oAction = 2;
 #endif
             break;

--- a/src/game/behaviors/lll_floating_wood_piece.inc.c
+++ b/src/game/behaviors/lll_floating_wood_piece.inc.c
@@ -1,6 +1,8 @@
 // lll_floating_wood_piece.c.inc
 
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 void bhv_lll_wood_piece_loop(void) {
     if (o->oTimer == 0)

--- a/src/game/behaviors/lll_rotating_hex_flame.inc.c
+++ b/src/game/behaviors/lll_rotating_hex_flame.inc.c
@@ -1,6 +1,8 @@
 // lll_rotating_hex_flame.c.inc
 
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 void bhv_lll_rotating_hex_flame_loop(void) {
     f32 sp24 = o->oLllRotatingHexFlameUnkF4;

--- a/src/game/behaviors/lll_rotating_hex_flame.inc.c
+++ b/src/game/behaviors/lll_rotating_hex_flame.inc.c
@@ -1,5 +1,7 @@
 // lll_rotating_hex_flame.c.inc
 
+#include "pc/configfile.h"
+
 void bhv_lll_rotating_hex_flame_loop(void) {
     f32 sp24 = o->oLllRotatingHexFlameUnkF4;
     f32 sp20 = o->oLllRotatingHexFlameUnkF8;
@@ -31,7 +33,7 @@ void fire_bar_spawn_flames(s16 a0) {
 
 void fire_bar_act_0(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 3000.0f)
+    if (o->oDistanceToMario < 30 * configDrawDistance)
 #endif
         o->oAction = 1;
 }
@@ -48,7 +50,7 @@ void fire_bar_act_2(void) {
     o->oAngleVelYaw = -0x100;
     o->oMoveAngleYaw += o->oAngleVelYaw;
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 3200.0f)
+    if (o->oDistanceToMario > 32 * configDrawDistance)
         o->oAction = 3;
 #endif
 }

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 /**
  * Behavior for bhvPiranhaPlant.
  * This controls Piranha Plants, which alternate between sleeping, attacking,
@@ -331,7 +333,7 @@ void bhv_piranha_plant_loop(void) {
     #ifndef NODRAWINGDISTANCE
     // In WF, hide all Piranha Plants once high enough up.
     if (gCurrLevelNum == LEVEL_WF) {
-        if (gMarioObject->oPosY > 3400.0f)
+        if (gMarioObject->oPosY > 34 * configDrawDistance)
             cur_obj_hide();
         else
             cur_obj_unhide();

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 /**
  * Behavior for bhvPiranhaPlant.

--- a/src/game/behaviors/pokey.inc.c
+++ b/src/game/behaviors/pokey.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 
 /**

--- a/src/game/behaviors/pokey.inc.c
+++ b/src/game/behaviors/pokey.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 
 /**
  * Behavior for bhvPokey and bhvPokeyBodyPart.
@@ -152,7 +154,7 @@ static void pokey_act_uninitialized(void) {
     s16 partModel;
 
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         partModel = MODEL_POKEY_HEAD;
 
@@ -190,7 +192,7 @@ static void pokey_act_wander(void) {
     if (o->oPokeyNumAliveBodyParts == 0) {
         obj_mark_for_deletion(o);
 #ifndef NODRAWINGDISTANCE
-    } else if (o->oDistanceToMario > 2500.0f) {
+    } else if (o->oDistanceToMario > 25 * configDrawDistance) {
         o->oAction = POKEY_ACT_UNLOAD_PARTS;
         o->oForwardVel = 0.0f;
 #endif

--- a/src/game/behaviors/sl_walking_penguin.inc.c
+++ b/src/game/behaviors/sl_walking_penguin.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // sl_walking_penguin.c.inc
 
 struct SLWalkingPenguinStep {
@@ -98,7 +100,7 @@ void bhv_sl_walking_penguin_loop(void) {
     
     cur_obj_move_standard(-78);
 #ifndef NODRAWINGDISTANCE
-     if (!cur_obj_hide_if_mario_far_away_y(1000.0f))
+     if (!cur_obj_hide_if_mario_far_away_y(10 * configDrawDistance))
 #endif
         play_penguin_walking_sound(PENGUIN_WALK_BIG);
     

--- a/src/game/behaviors/sl_walking_penguin.inc.c
+++ b/src/game/behaviors/sl_walking_penguin.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // sl_walking_penguin.c.inc
 

--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 /**
  * Behavior file for bhvSnufit and bhvSnufitBalls.
  * Snufits are present in HMC and CotMC, and are the fly guy
@@ -181,7 +183,7 @@ void bhv_snufit_balls_loop(void) {
     // If far from Mario or in a different room, despawn.
     if ((o->activeFlags & ACTIVE_FLAG_IN_DIFFERENT_ROOM)
 #ifndef NODRAWINGDISTANCE
-        || (o->oTimer != 0 && o->oDistanceToMario > 1500.0f)
+        || (o->oTimer != 0 && o->oDistanceToMario > 15 * configDrawDistance)
 #endif
             ){
         obj_mark_for_deletion(o);

--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 /**
  * Behavior file for bhvSnufit and bhvSnufitBalls.

--- a/src/game/behaviors/triplet_butterfly.inc.c
+++ b/src/game/behaviors/triplet_butterfly.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 struct TripletButterflyActivationData {
     s32 model;
     const BehaviorScript *behavior;
@@ -55,7 +57,7 @@ static void triplet_butterfly_act_init(void) {
 
 static void triplet_butterfly_act_wander(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 1500.0f) {
+    if (o->oDistanceToMario > 15 * configDrawDistance) {
         obj_mark_for_deletion(o);
     } else {
 #endif

--- a/src/game/behaviors/triplet_butterfly.inc.c
+++ b/src/game/behaviors/triplet_butterfly.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 struct TripletButterflyActivationData {
     s32 model;

--- a/src/game/behaviors/water_bomb_cannon.inc.c
+++ b/src/game/behaviors/water_bomb_cannon.inc.c
@@ -1,5 +1,7 @@
 // water_bomb_cannon.inc.c
 
+#include "pc/configfile.h"
+
 void bhv_bubble_cannon_barrel_loop(void) {
     struct Object *val04;
 
@@ -39,7 +41,7 @@ void bhv_bubble_cannon_barrel_loop(void) {
 
 void water_bomb_cannon_act_0(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 2000.0f) {
+    if (o->oDistanceToMario < 20 * configDrawDistance) {
 #endif
         spawn_object(o, MODEL_CANNON_BARREL, bhvCannonBarrelBubbles);
         cur_obj_unhide();
@@ -53,7 +55,7 @@ void water_bomb_cannon_act_0(void) {
 
 void water_bomb_cannon_act_1(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario > 2500.0f) {
+    if (o->oDistanceToMario > 25 * configDrawDistance) {
         o->oAction = 2;
     } else if (o->oBehParams2ndByte == 0) {
 #else

--- a/src/game/behaviors/water_bomb_cannon.inc.c
+++ b/src/game/behaviors/water_bomb_cannon.inc.c
@@ -1,6 +1,8 @@
 // water_bomb_cannon.inc.c
 
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 void bhv_bubble_cannon_barrel_loop(void) {
     struct Object *val04;

--- a/src/game/behaviors/whirlpool.inc.c
+++ b/src/game/behaviors/whirlpool.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // whirlpool.c.inc
 
 static struct ObjectHitbox sWhirlpoolHitbox = {
@@ -36,7 +38,7 @@ void whirpool_orient_graph(void) {
 
 void bhv_whirlpool_loop(void) {
 #ifndef NODRAWINGDISTANCE
-    if (o->oDistanceToMario < 5000.0f) {
+    if (o->oDistanceToMario < 50 * configDrawDistance) {
 #endif
         o->header.gfx.node.flags &= ~GRAPH_RENDER_INVISIBLE;
 

--- a/src/game/behaviors/whirlpool.inc.c
+++ b/src/game/behaviors/whirlpool.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // whirlpool.c.inc
 

--- a/src/game/behaviors/whomp.inc.c
+++ b/src/game/behaviors/whomp.inc.c
@@ -1,4 +1,6 @@
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 
 // whomp.c.inc
 

--- a/src/game/behaviors/whomp.inc.c
+++ b/src/game/behaviors/whomp.inc.c
@@ -1,3 +1,5 @@
+#include "pc/configfile.h"
+
 // whomp.c.inc
 
 void whomp_play_sfx_from_pound_animation(void) {
@@ -250,9 +252,9 @@ void bhv_whomp_loop(void) {
         // o->oBehParams2ndByte here seems to be a flag
         // indicating whether this is a normal or king whomp
         if (o->oBehParams2ndByte != 0)
-            cur_obj_hide_if_mario_far_away_y(2000.0f);
+            cur_obj_hide_if_mario_far_away_y(20 * configDrawDistance);
         else
-            cur_obj_hide_if_mario_far_away_y(1000.0f);
+            cur_obj_hide_if_mario_far_away_y(10 * configDrawDistance);
 #endif
         load_object_collision_model();
     }

--- a/src/game/obj_behaviors.c
+++ b/src/game/obj_behaviors.c
@@ -27,7 +27,9 @@
 #include "obj_behaviors.h"
 #include "object_helpers.h"
 #include "object_list_processor.h"
+#ifndef NODRAWINGDISTANCE
 #include "pc/configfile.h"
+#endif
 #include "rendering_graph_node.h"
 #include "save_file.h"
 #include "spawn_object.h"

--- a/src/game/obj_behaviors.c
+++ b/src/game/obj_behaviors.c
@@ -27,6 +27,7 @@
 #include "obj_behaviors.h"
 #include "object_helpers.h"
 #include "object_list_processor.h"
+#include "pc/configfile.h"
 #include "rendering_graph_node.h"
 #include "save_file.h"
 #include "spawn_object.h"
@@ -531,7 +532,7 @@ void set_object_visibility(struct Object *obj, s32 dist) {
     f32 objZ = obj->oPosZ;
 
 #ifndef NODRAWINGDISTANCE
-    if (is_point_within_radius_of_mario(objX, objY, objZ, dist) == TRUE) {
+    if (is_point_within_radius_of_mario(objX, objY, objZ, dist * configDrawDistance / 100) == TRUE) {
 #endif
         obj->header.gfx.node.flags &= ~GRAPH_RENDER_INVISIBLE;
 #ifndef NODRAWINGDISTANCE

--- a/src/game/options_menu.c
+++ b/src/game/options_menu.c
@@ -85,6 +85,7 @@ static const u8 optsVideoStr[][32] = {
     { TEXT_OPT_AUTO },
     { TEXT_OPT_HUD },
     { TEXT_OPT_THREEPT },
+    { TEXT_OPT_DRAWDIST },
     { TEXT_OPT_APPLY },
 };
 
@@ -261,8 +262,11 @@ static struct Option optsVideo[] = {
     DEF_OPT_TOGGLE( optsVideoStr[5], &configWindow.vsync ),
     DEF_OPT_CHOICE( optsVideoStr[1], &configFiltering, filterChoices ),
     DEF_OPT_TOGGLE( optsVideoStr[7], &configHUD ),
+#ifndef NODRAWINGDISTANCE
+    DEF_OPT_SCROLL( optsVideoStr[9], &configDrawDistance, 50, 509, 10 ),
+#endif
     DEF_OPT_BUTTON( optsVideoStr[4], optvideo_reset_window ),
-    DEF_OPT_BUTTON( optsVideoStr[9], optvideo_apply ),
+    DEF_OPT_BUTTON( optsVideoStr[10], optvideo_apply ),
 };
 
 static struct Option optsAudio[] = {

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -90,6 +90,9 @@ bool         configCameraMouse   = false;
 #endif
 bool         configSkipIntro     = 0;
 bool         configHUD           = true;
+#ifndef NODRAWINGDISTANCE
+unsigned int configDrawDistance  = 100;
+#endif
 #ifdef DISCORDRPC
 bool         configDiscordRPC    = true;
 #endif
@@ -102,6 +105,9 @@ static const struct ConfigOption options[] = {
     {.name = "window_h",             .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.h},
     {.name = "vsync",                .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.vsync},
     {.name = "texture_filtering",    .type = CONFIG_TYPE_UINT, .uintValue = &configFiltering},
+    #ifndef NODRAWINGDISTANCE
+    {.name = "drawing_distance",     .type = CONFIG_TYPE_UINT, .uintValue = &configDrawDistance},
+    #endif
     {.name = "master_volume",        .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "music_volume",         .type = CONFIG_TYPE_UINT, .uintValue = &configMusicVolume},
     {.name = "sfx_volume",           .type = CONFIG_TYPE_UINT, .uintValue = &configSfxVolume},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -55,6 +55,9 @@ extern bool         configCameraMouse;
 extern bool         configCameraAnalog;
 #endif
 extern bool         configHUD;
+#ifndef NODRAWINGDISTANCE
+extern unsigned int configDrawDistance;
+#endif
 extern bool         configSkipIntro;
 #ifdef DISCORDRPC
 extern bool         configDiscordRPC;


### PR DESCRIPTION
This adds a new setting to the Display menu that lets you change the draw distance to anywhere between 0.5x and 5x the original game's draw distance, in 10% increments. This should be useful for weaker devices like a Raspberry Pi that can't handle the NODRAWINGDISTANCE build option. This option does not appear in the menu if NODRAWINGDISTANCE is used.

This was implemented by adding a new variable that is multiplied with every instance where an object's distance to Mario is compared in an "#ifndef NODRAWINGDISTANCE" define. Additionally, all of the original draw distances are divided by 100 since 100 represents a normal draw distance. The end result is the same, but this removes the need for continuous float multiplication where applicable (example: "2400.0f" becomes "24 * configDrawDistance", where configDrawDistance is an integer between 50 and 500, default=100).