### PR TITLE
Load gamecontrollerdb.txt before SDL_Init (Nightly)

### DIFF
--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -89,13 +89,6 @@ static void controller_sdl_bind(void) {
 }
 
 static void controller_sdl_init(void) {
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS) != 0) {
-        fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
-        return;
-    }
-
-    haptics_enabled = (SDL_InitSubSystem(SDL_INIT_HAPTIC) == 0);
-
     // try loading an external gamecontroller mapping file
     uint64_t gcsize = 0;
     void *gcdata = fs_load_file("gamecontrollerdb.txt", &gcsize);
@@ -108,6 +101,13 @@ static void controller_sdl_init(void) {
         }
         free(gcdata);
     }
+
+    if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS) != 0) {
+        fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
+        return;
+    }
+
+    haptics_enabled = (SDL_InitSubSystem(SDL_INIT_HAPTIC) == 0);
 
 #ifdef BETTERCAMERA
     if (newcam_mouse == 1)


### PR DESCRIPTION
If you load the mappings after SDL_Init, any connected controllers won't get the new mappings.