### PR TITLE
Add NO_PIE option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ TARGET_WEB ?= 0
 # Makeflag to enable OSX fixes
 OSX_BUILD ?= 0
 
+# Enable -no-pie linker option
+NO_PIE ?= 1
+
 # Specify the target you are building for, TARGET_BITS=0 means native
 TARGET_ARCH ?= native
 TARGET_BITS ?= 0
@@ -638,9 +641,13 @@ else ifeq ($(OSX_BUILD),1)
   LDFLAGS := -lm $(BACKEND_LDFLAGS) -no-pie -lpthread
 
 else
-  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -no-pie -lpthread
+  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+  ifeq ($(NO_PIE), 1)
+    LDFLAGS += -no-pie
+  endif
+
   ifeq ($(DISCORDRPC),1)
-    LDFLAGS += -ldl -Wl,-rpath .
+    LDFLAGS += -Wl,-rpath .
   endif
 
 endif # End of LDFLAGS


### PR DESCRIPTION
I added this because `-no-pie` isn't supported by GCC 4.9.3 and I wanted to build this using the buildroot 2015.11.1 toolchain with the following command

    make CROSS=arm-buildroot-linux-gnueabihf- CXX="arm-buildroot-linux-gnueabihf-c++" CC="arm-buildroot-linux-gnueabihf-gcc -std=c11 -DM_PI=3.14159265358979323846 -D_POSIX_C_SOURCE=199309L" SDLCONFIG=sdl2-config AS=arm-buildroot-linux-gnueabihf-as TARGET_ARCH=armv7-a NO_PIE=0