### PR TITLE
edit extract_assets script to support FreeBSD

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -2,13 +2,12 @@
 import sys
 import os
 import json
-
+import platform
 
 def read_asset_map():
     with open("assets.json") as f:
         ret = json.load(f)
     return ret
-
 
 def read_local_asset_list(f):
     if f is None:
@@ -17,7 +16,6 @@ def read_local_asset_list(f):
     for line in f:
         ret.append(line.strip())
     return ret
-
 
 def asset_needs_update(asset, version):
     if version <= 5 and asset == "textures/spooky/bbh_textures.00800.rgba16.png":
@@ -34,7 +32,6 @@ def asset_needs_update(asset, version):
         return True
     return False
 
-
 def remove_file(fname):
     os.remove(fname)
     print("deleting", fname)
@@ -42,7 +39,6 @@ def remove_file(fname):
         os.removedirs(os.path.dirname(fname))
     except OSError:
         pass
-
 
 def clean_assets(local_asset_file):
     assets = set(read_asset_map().keys())
@@ -54,7 +50,6 @@ def clean_assets(local_asset_file):
             remove_file(fname)
         except FileNotFoundError:
             pass
-
 
 def main():
     # In case we ever need to change formats of generated files, we keep a
@@ -153,9 +148,14 @@ def main():
             sys.exit(1)
 
     # Make sure tools exist
-    subprocess.check_call(
-        ["make", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
-    )
+    if platform.system() == "FreeBSD":
+        subprocess.check_call(
+            ["gmake", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
+        )
+    else:
+        subprocess.check_call(
+            ["make", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
+        )
 
     # Go through the assets in roughly alphabetical order (but assets in the same
     # mio0 file still go together).
@@ -282,5 +282,4 @@ def main():
     with open(".assets-local.txt", "w") as f:
         f.write(output)
 
-
-main()
+main() if __name__ == "__main__" else None


### PR DESCRIPTION
This PR makes some simple edits to the extract assets script to add support for FreeBSD. It

* Fixes the line that is responsible for checking if the tools exist (new if statement+import to find if the system is a FreeBSD system)
* `main() if __name__ == "__main__" else None` statement for safety (leaving a line that calls `main()` without checking if the script was called directly is a bad idea!)

# Important: Add a wiki entry for building on FreeBSD.

This PR assumes that the following is added to the wiki as a new entry that tells users how to build on FreeBSD. The contents of the markdown file should be the following:

```
# Building on FreeBSD

Tested on:

* FreeBSD 13.1-RELEASE
* FreeBSD 13.2-RC5
* FreeBSD 13.2-RC6

# Copying the baserom(s) for asset extraction.

For each version (Japanese\[jp\],American\[us\] or European\[eu\]) that you would like to build an executable for, copy an existing ROM to `./baserom.<version>.z64` (root of the folder).

# Installing the Build Dependencies

The build has several dependencies (for compilation) on FreeBSD:

* python3 (>=3.6) (should be pre-installed on most desktops, but issue `pkg install python3` if unsure)
* sdl2 with development headers
* glew with development headers
* gnu make (gmake)

So to install, issue

`pkg install gmake sdl2 glew` to install the packages.

# Building the executable

Issue `gmake` to compile. To enable and disable certain features, either edit the `Makefile` or just append some build flags to your `gmake` invocation, like so:

`gmake BETTERCAMERA=1 EXTERNAL_DATA=1 -j4`
```

if this PR is not accepted and the wiki is added,  please add a section that describes how the user should be able to patch the extract_assets script, something like:

```
# Patching the `extract_assets` script

Because the extract_assets script assumes one has GNU make as `make` and FreeBSD has BSD make as `make`, one has to patch line 157 from

`["make", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]` to `["gmake", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]`.

(patch available below:)

```patch
--- extract_assets.old.py       2023-04-02 19:12:48.247850000 +0800
+++ extract_assets.py   2023-04-02 19:07:14.504789000 +0800
@@ -154,7 +154,7 @@
 
     # Make sure tools exist
     subprocess.check_call(
-        ["make", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
+        ["gmake", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
     )
 
     # Go through the assets in roughly alphabetical order (but assets in the same
```'
```

Willing to make further commits if any other bugs that will affect FreeBSD users are found. The new code was tested on:

* 13.1-RELEASE
* 13.2-RC5
* 13.2-RC6

(older versions should theoretically work, given a high enough SDL2, GLEW and Python version, the oldest production release, currently 12.4-RELEASE should work.)
