### PR TITLE
Fixed invalid messageID on menus

### DIFF
--- a/src/menu/file_select.c
+++ b/src/menu/file_select.c
@@ -836,7 +836,7 @@ void check_copy_menu_clicked_buttons(struct Object *copyButton) {
                 // If menu button clicked, select it
                 if (buttonID == MENU_BUTTON_COPY_RETURN || buttonID == MENU_BUTTON_COPY_CHECK_SCORE
                     || buttonID == MENU_BUTTON_COPY_ERASE_FILE) {
-                    if (copyButton->oMenuButtonActionPhase == COPY_PHASE_MAIN) {
+                    if (copyButton->oMenuButtonActionPhase == COPY_PHASE_MAIN && sMainMenuTimer >= ACTION_TIMER) {
                         play_sound(SOUND_MENU_CLICK_FILE_SELECT, gDefaultSoundArgs);
                         sMainMenuButtons[buttonID]->oMenuButtonState = MENU_BUTTON_STATE_ZOOM_IN_OUT;
                         sSelectedButtonID = buttonID;


### PR DESCRIPTION
Fixed entering an invalid messageID state from copy menu, fixing the famous file select screen crash.