### PR TITLE
Update Dockerfile to Ubuntu 22.04 as 18.04 is EOL + Clean up unused packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \
+        bsdextrautils \
         build-essential \
         git \
         libglew-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN mkdir /sm64ex
 WORKDIR /sm64ex
 ENV PATH="/sm64ex/tools:${PATH}"
 
-CMD echo 'usage: docker run --rm -v ${PWD}:/sm64ex sm64ex make BETTERCAMERA=1 EXTERNAL_DATA=1 -j4\n' \
-         'see https://github.com/sm64pc/sm64ex/wiki/Compiling-on-Docker for advanced usage'
+CMD echo 'Usage: docker run --rm -v ${PWD}:/sm64ex sm64ex make BETTERCAMERA=1 EXTERNAL_DATA=1 -j4\n' \
+         'See https://github.com/sm64pc/sm64ex/wiki/Compiling-on-Docker for more information'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,16 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \
-        binutils-mips-linux-gnu \
-        bsdmainutils \
         build-essential \
-        libaudiofile-dev \
-        python3 \
-        wget \
         git \
         libglew-dev \
-        libsdl2-dev
+        libsdl2-dev \
+        python3
 
-RUN wget \
-        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
-        -O qemu.deb && \
-    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
-    dpkg -i qemu.deb && \
-    rm qemu.deb
+RUN mkdir /sm64ex
+WORKDIR /sm64ex
+ENV PATH="/sm64ex/tools:${PATH}"
 
-RUN mkdir /sm64
-WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
-
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'usage: docker run --rm -v ${PWD}:/sm64ex sm64ex make BETTERCAMERA=1 EXTERNAL_DATA=1 -j4\n' \
+         'see https://github.com/sm64pc/sm64ex/wiki/Compiling-on-Docker for advanced usage'


### PR DESCRIPTION
Installation instructions available here: https://github.com/MisterSheeple/sm64ex/wiki/Compiling-on-Docker Feel free to copy this page to your own wiki if you merge this.

This PR also removes some apt packages from the Dockerfile that were used for the original decomp and are no longer required here.

Relevant pull request over here: https://github.com/n64decomp/sm64/pull/91