### PR TITLE
Add SDL2 Background Input Patch

### DIFF
--- a/enhancements/background_input.patch
+++ b/enhancements/background_input.patch
@@ -1,0 +1,12 @@
+diff --git a/src/pc/controller/controller_sdl2.c b/src/pc/controller/controller_sdl2.c
+index 2001e7f..2098618 100644
+--- a/src/pc/controller/controller_sdl2.c
++++ b/src/pc/controller/controller_sdl2.c
+@@ -51,6 +51,7 @@ static u32 last_mouse = VK_INVALID;
+ static u32 last_joybutton = VK_INVALID;
+ 
+ static inline void controller_add_binds(const u32 mask, const u32 *btns) {
++    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+     for (u32 i = 0; i < MAX_BINDS; ++i) {
+         if (btns[i] >= VK_BASE_SDL_GAMEPAD && btns[i] <= VK_BASE_SDL_GAMEPAD + VK_SIZE) {
+             if (btns[i] >= VK_BASE_SDL_MOUSE && num_joy_binds < MAX_JOYBINDS) {


### PR DESCRIPTION
This adds a patch for allowing background controller inputs with SDL2. Not sure if we want this to be the default, a configurable option after compile, or if this is fine as a patch. It's a pretty simple one-line change either way.

Without this patch clicking off the game disables controller input.