### PR TITLE
Fix DPI scaling issues on Windows (OpenGL)

### DIFF
--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -151,6 +151,11 @@ static void gfx_sdl_reset_dimension_and_pos(void) {
 }
 
 static void gfx_sdl_init(const char *window_title) {
+    #if SDL_VERSION_ATLEAST(2,24,0)
+        /* fix DPI scaling issues on Windows */
+        SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+    #endif
+
     SDL_Init(SDL_INIT_VIDEO);
 
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);


### PR DESCRIPTION
Adds an SDL hint to address DPI scaling issues on Windows when using OpenGL, where the window size can appear too large. This also helps with the resolution in fullscreen, making things look less crunchy (200% DPI).

before
![image](https://github.com/user-attachments/assets/6d456671-a6b1-42b0-b6dc-372083662960)

after
![image](https://github.com/user-attachments/assets/7d9a32c6-81ec-4c4c-996d-dcf07f71f35e)
