### PR TITLE
Big endian 64bit fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -674,7 +674,14 @@ else ifeq ($(HOST_OS),Haiku)
   LDFLAGS := $(BACKEND_LDFLAGS) -no-pie
 
 else
-  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+#  ifneq (,$(findstring ppc64,$(machine)))
+#  LDFLAGS := $(BITS) -maltivec -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+#  endif
+#  ifneq (,$(findstring powerpc,$(machine)))
+#  LDFLAGS := $(BITS) -maltivec -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+#  endif
+#  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+  LDFLAGS := $(BITS) -maltivec -lm $(BACKEND_LDFLAGS) -lpthread -ldl
   ifeq ($(NO_PIE), 1)
     LDFLAGS += -no-pie
   endif

--- a/Makefile
+++ b/Makefile
@@ -675,9 +675,9 @@ else ifeq ($(HOST_OS),Haiku)
 
 else ifeq (,$(findstring powerpc,$(machine)))
   LDFLAGS := $(BITS) -mcpu=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+
 else
   LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
-endif
   ifeq ($(NO_PIE), 1)
     LDFLAGS += -no-pie
   endif

--- a/Makefile
+++ b/Makefile
@@ -673,8 +673,7 @@ else ifeq ($(OSX_BUILD),1)
 else ifeq ($(HOST_OS),Haiku)
   LDFLAGS := $(BACKEND_LDFLAGS) -no-pie
 
-else
-ifeq ($(TARGET_ARCH),powerpc)
+else ifeq (,$(findstring powerpc,$(machine)))
   LDFLAGS := $(BITS) -mcpu=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
 else
   LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl

--- a/Makefile
+++ b/Makefile
@@ -674,14 +674,11 @@ else ifeq ($(HOST_OS),Haiku)
   LDFLAGS := $(BACKEND_LDFLAGS) -no-pie
 
 else
-#  ifneq (,$(findstring ppc64,$(machine)))
-#  LDFLAGS := $(BITS) -mcpu=native -lm $(BACKEND_LDFLAGS) -lpthread -ldl
-#  endif
-#  ifneq (,$(findstring powerpc,$(machine)))
-#  LDFLAGS := $(BITS) -mcpu=native -lm $(BACKEND_LDFLAGS) -lpthread -ldl
-#  endif
-#  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
-  LDFLAGS := $(BITS) -mcpu=native -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+ifeq ($(TARGET_ARCH),powerpc)
+  LDFLAGS := $(BITS) -mcpu=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+else
+  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+endif
   ifeq ($(NO_PIE), 1)
     LDFLAGS += -no-pie
   endif

--- a/Makefile
+++ b/Makefile
@@ -675,13 +675,13 @@ else ifeq ($(HOST_OS),Haiku)
 
 else
 #  ifneq (,$(findstring ppc64,$(machine)))
-#  LDFLAGS := $(BITS) -maltivec -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+#  LDFLAGS := $(BITS) -mcpu=native -lm $(BACKEND_LDFLAGS) -lpthread -ldl
 #  endif
 #  ifneq (,$(findstring powerpc,$(machine)))
-#  LDFLAGS := $(BITS) -maltivec -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+#  LDFLAGS := $(BITS) -mcpu=native -lm $(BACKEND_LDFLAGS) -lpthread -ldl
 #  endif
 #  LDFLAGS := $(BITS) -march=$(TARGET_ARCH) -lm $(BACKEND_LDFLAGS) -lpthread -ldl
-  LDFLAGS := $(BITS) -maltivec -lm $(BACKEND_LDFLAGS) -lpthread -ldl
+  LDFLAGS := $(BITS) -mcpu=native -lm $(BACKEND_LDFLAGS) -lpthread -ldl
   ifeq ($(NO_PIE), 1)
     LDFLAGS += -no-pie
   endif

--- a/src/goddard/gd_types.h
+++ b/src/goddard/gd_types.h
@@ -27,7 +27,11 @@ struct GdColour {
 union DynUnion {
     void *ptr;
     char *str;
-    s32 word;
+#if IS_BIG_ENDIAN && IS_64_BIT
+    s64 word;
+#else
+     s32 word;
+#endif
 };
 
 struct DynList {

--- a/src/goddard/gd_types.h
+++ b/src/goddard/gd_types.h
@@ -30,7 +30,7 @@ union DynUnion {
 #if IS_BIG_ENDIAN && IS_64_BIT
     s64 word;
 #else
-     s32 word;
+    s32 word;
 #endif
 };
 


### PR DESCRIPTION
This should fix #426

GCC for PowerPC don't have -march=native but accepts -mcpu=native.

Best regards,
Link.