### PR TITLE
skyconv fix "buffer overflow detected"

### DIFF
--- a/tools/skyconv.c
+++ b/tools/skyconv.c
@@ -250,7 +250,7 @@ void write_tiles() {
     for (int i = 0; i < props.numRows * props.numCols; i++) {
         if (!tiles[i].useless) {
             *filename = 0;
-            snprintf(filename, PATH_MAX, ".%d.rgba16.png", tiles[i].pos);
+            snprintf(filename, PATH_MAX - dirLength, ".%d.rgba16.png", tiles[i].pos);
             rgba2png(buffer, tiles[i].px, props.tileWidth, props.tileHeight);
         }
     }
@@ -284,7 +284,7 @@ static void write_skybox_c() { /* write c data to disc */
         exit(EXIT_FAILURE);
     }
 
-    sprintf(fBuffer, "%s/%s_skybox.c", output, skyboxName);
+    snprintf(fBuffer, PATH_MAX, "%s/%s_skybox.c", output, skyboxName);
     cFile = fopen(fBuffer, "w"); /* reset file */
 
     /* setup C file */


### PR DESCRIPTION
On my Ubuntu 24.04.1 with GCC 13.3.0, GLIBC 2.39, build fails due to skyconv

```
tools/skyconv --store-names --write-tiles build/us_pc/textures/skybox_tiles --type cake --split levels/ending/cake.png build/us_pc/levels/ending
***buffer overflow detected ***: terminated
Aborted (core dump)
```

snprintf uses PATH_MAX as length while that's not the actual remaining space in the buffer. There might be an internal check in glibc that causes this crash.
As a bonus, the sprintf below has been replaced to snprintf (shouldn't cause any issues).