### PR TITLE
Fix implicit declaration error for audio_reset_session

### DIFF
--- a/src/audio/port_eu.c
+++ b/src/audio/port_eu.c
@@ -4,6 +4,7 @@
 #include "data.h"
 #include "seqplayer.h"
 #include "synthesis.h"
+#include "heap.h"
 
 #ifdef VERSION_EU
 


### PR DESCRIPTION
Fixed the build failure as described in #535.

The compiled binary still has a problem though: Audio initially plays in each level (or after each level transition) for a few seconds, but then stops or fades out. This only occurs in the EU version and not in the US version. This problem is not fixed in this PR, only the pure build failure.